### PR TITLE
<fix> wandb 초기화 이슈하고 config 파일 제대로 반영안되던 것 수정했습니다.

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,13 +83,11 @@
         "eval_retrieval": true
     },
     "train": {
-        "output_dir": "ST02",
+        "load_best_model_at_end": true,
         "save_total_limit": 2
     }
 }
 ```
-
-
 
 ## How to Usage
 

--- a/config/train_args.py
+++ b/config/train_args.py
@@ -9,3 +9,5 @@ class TrainArguments:
     """
 
     output_dir: Optional[str] = field(default="train_checkpoint", metadata={"help": "checkpoint_dir"})
+    report_to: Optional[list] = field(default=["wandb"], metadata={"help": "wandb or tensorboard"})
+    logging_steps: Optional[int] = field(default=100, metadata={"help": "logging_steps"})

--- a/run.py
+++ b/run.py
@@ -1,3 +1,4 @@
+import wandb
 import os.path as p
 from itertools import product
 from argparse import Namespace
@@ -14,6 +15,7 @@ def train_reader(args):
     seeds = args.seeds[: args.run_cnt]
 
     for idx, (seed, strategy) in enumerate(product(seeds, strategis)):
+        wandb.init(project="p-stage-3", reinit=True)
         args = update_args(args, strategy)  # auto add args.save_path, args.base_path
         args.strategy, args.seed = strategy, seed
         args.info = Namespace()

--- a/tools.py
+++ b/tools.py
@@ -37,8 +37,10 @@ def update_args(args, strategy):
 
     args.alias = temp["alias"]
     for arg_type in ["model", "data", "train"]:
+        temp_type = getattr(args, arg_type)
         for k, v in temp[arg_type].items():
-            setattr(args, k, v)
+            setattr(temp_type, k, v)
+
     return args
 
 


### PR DESCRIPTION
wandb.init(project="p-stage-3", reinit=True) 명령어 추가했습니다.

config 파일에서 output_dir 인자 넣으면 안됩니다.
{
    "train": {
        ~~"output_dir": ''"~~
    } 
}