### PR TITLE
(fix) README typo, (refactor) get embedding in retriever

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ ST01, ST02 전략을 다른 seed값으로 3번씩 실행
 python -m run --strategis ST01 --run_cnt 3
 ```
 
-**Train Reulst**
+**Train Result**
 
 - input
     - checkpoint
@@ -134,7 +134,7 @@ python -m run --strategis ST01 --run_cnt 3
 python -m run --strategis ST01 --model_path ../input/checkpoint/ST02_95_temp/checkpoint-500
 ```
 
-**Predict Reulst**
+**Predict Result**
 
 - input
     - checkpoint

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@
         - BM25
             - embeddding.bin
             - bm25.bin
-        - desne_bert ( dense는 docs임베딩을 저장하거나, token vector를 저장할 듯 싶습니다.)
+        - dense_bert (dense는 docs임베딩을 저장하거나, token vector를 저장할 듯 싶습니다.)
             - embeddding.bin
             - dense_bert.bin
         ...

--- a/prepare.py
+++ b/prepare.py
@@ -21,6 +21,7 @@ def get_retriever(args):
 
         mecab = Mecab()
         retriever = SparseRetrieval(args, tokenize_fn=mecab.morphs)
+        retriever.get_sparse_embedding()
     return retriever
 
 

--- a/run.py
+++ b/run.py
@@ -25,7 +25,6 @@ def train_reader(args):
         model, tokenizer = get_reader_model(args)
 
         retriever = get_retriever(args)
-        retriever.get_sparse_embedding()
 
         train_dataset, post_processing_function = preprocess_dataset(args, datasets, tokenizer, is_train=True)
 


### PR DESCRIPTION
1. README typo
오타 몇 개 수정했습니다 .. : ) 

2. get embedding in retriever
앞서 issue에서 제안한거 문제없이 돌아가는거 확인해서 일단 PR 넣어놓습니다!
*retriever 불러올 때 sparse embedding을 함께 가져옵니다.