### PR TITLE
<refactor> reader refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,61 +1,94 @@
-# VumbleBot - BaselineCode
+# VumbleBot - BaselineCode <!-- omit in toc -->
+
+- [Branch](#branch)
+- [File Structure](#file-structure)
+  - [input](#input)
+  - [baseline_code](#baseline_code)
+- [Json File Example](#json-file-example)
+- [Usage](#usage)
+  - [Usage: Train](#usage-train)
+    - [Train result](#train-result)
+  - [Usage: Predict](#usage-predict)
+    - [Predict result](#predict-result)
+- [TDD](#tdd)
 
 ## Branch 
 
 - 코드 수정 후 main branch로 pull request
 
-## ISSUE
-
-- run.py에서 train 이후에 evaluate 진행
-- inference.py -> predict.py로 파일 수정
-
-## 파일 구조
+## File Structure
 
 **굵게** 칠해진 곳은 아직 코딩중입니다.. :(
 
-- input
-    - checkpoint (strategy, seed, alias: 별칭)
-        - ST01_95_base
-            - ...
-        - ST02_95_temp
-            - ...
-    - config
-        - ST01.json
-        - ST02.json
-    - data (Competiton 데이터)
-        - train_data
-        - test_data
-        - dummy_data
-    - embed (데이터랑 알고리즘에 종속적인데 데이터(wikidocs.json)는 변하지 않음)
-        - TFIDF
-            - embeddding.bin
-            - tfidv.bin
-        - BM25
-            - embeddding.bin
-            - bm25.bin
-        - dense_bert (dense는 docs임베딩을 저장하거나, token vector를 저장할 듯 싶습니다.)
-            - embeddding.bin
-            - dense_bert.bin
-        ...
-    - **info (시각화에 사용되기 위한 정보들 Logging)**
-        - ST01_95_base.json
-        - ST02_95_temp.json
-- new_baseline_code
-    - post_process
-        - answer
-        - document
-    - retriever
-        - sparse
-        - dense
-    - predict.py
-    - prepare.py 
-    - run.py 
-    - tokenization_bert.py ( `kobert`, `distilkobert` )
-    - tools.py
-    - trainer_qa.py
-    - utils_qa.py
-    - tester.py
-
+### input
+  
+```
+input/
+│ 
+├── config/ - strategies
+│   ├── ST01.json
+│   └── ...
+│
+├── checkpoint/ - checkpoints&predictions (strategy_alias_seed)
+│   ├── ST01_base_00
+│   ├── ST01_base_95
+│   └── ...
+│ 
+├── data/ - competition data
+│   ├── dummy_data/
+│   ├── train_data/
+│   └── test_data/
+│
+├── embed/ - embedding caches of `wikidocs.json`
+│   ├── TFIDF/
+│   │   ├── embedding.bin
+│   │   └── tfidv.bin
+│   ├── BM25/
+│   └── DPR/
+│
+├── info/ - logging (for visualization)
+│   └── NOT IMPLEMENTED YET
+│ 
+└── config/ - arguments
+    ├── data_args.py
+    ├── model_args.py
+    └── train_args.py
+```
+    
+### baseline_code
+  
+```
+odqa_baseline_code/
+│
+├── reader/ - reader
+│   └── base_reader.py
+│
+├── retrieval/ - retriever
+│   ├── sparse/
+│   │   ├── tfidf.py
+│   │   └── bm25.py
+│   │
+│   └── dense/
+│       └── dpr.py
+│       
+├── trainer_qa.py - trainer(custom evaluate, predict)
+├── utils_qa.py - post processing function
+├── prepare.py - get datasets/retriever/reader    
+├── tools.py - arguments/tester
+│
+├── tester.py - debugging, testing
+│
+├── run.py - train/evaluate
+├── predict.py - inference
+│
+├── tokenization_kobert.py - tokenizer ( `kobert`, `distilkobert` )
+│
+│
+└── config/ - arguments
+    ├── data_args.py
+    ├── model_args.py
+    └── train_args.py
+```
 
 ## Json File Example
 
@@ -86,6 +119,8 @@ ST00.json 하이퍼파라미터는 아래 파일들을 참고해서 수정할 �
         "eval_retrieval": true
     },
     "train": {
+        "do_train": true,
+        "do_eval": true,
         "save_total_limit": 2,
         "save_steps": 100,
         "logging_steps": 100,
@@ -95,7 +130,7 @@ ST00.json 하이퍼파라미터는 아래 파일들을 참고해서 수정할 �
 }
 ```
 
-## How to Usage
+## Usage
 
 Server의 디렉토리 구조에서 input과 같은 수준에 위치하면 됩니다.
 
@@ -103,20 +138,15 @@ Server의 디렉토리 구조에서 input과 같은 수준에 위치하면 됩�
 - code
 - new_baseline_code
 
-### How to Usage: Train
-
-```
-python -m run --strategies ST01,ST02 --run_cnt 3
-```
-
-ST01, ST02 전략을 다른 seed값으로 3번씩 실행
-
-```
-python -m run --strategies ST01 --run_cnt 3
-```
-
-**Train Result**
-
+### Usage: Train   
+  
+- ST01 전략을 서로 다른 seed 값으로 3번 실행  
+`python -m run --strategies ST01 --run_cnt 3`    
+- ST01, ST02 전략을 서로 다른 seed 값으로 3번씩 실행 (총 6번)   
+`python -m run --strategies ST01,ST02 --run_cnt 3`   
+  
+#### Train result  
+  
 - input
     - checkpoint
         -ST02_95_temp
@@ -124,16 +154,13 @@ python -m run --strategies ST01 --run_cnt 3
         - nbest_predictions_valid.json
         - predictions_valid.json
 
-### How to Usage: Predict
+### Usage: Predict
 
-- strategies 한 개의 전략만 집어넣는 것을 추천합니다.
-
-```
-python -m run --strategies ST01 --model_path ../input/checkpoint/ST02_95_temp/checkpoint-500
-```
-
-**Predict Result**
-
+- strategies로 한 개의 전략만 집어넣는 것을 추천합니다.  
+`python -m run --strategies ST01 --model_path ../input/checkpoint/ST02_95_temp/checkpoint-500`  
+  
+#### Predict result  
+ 
 - input
     - checkpoint
         -ST01
@@ -142,21 +169,17 @@ python -m run --strategies ST01 --model_path ../input/checkpoint/ST02_95_temp/ch
 
 
 단일 실행도 가능합니다.
-
-# TDD
+  
+## TDD
 | [tester.py](./tester.py) : 구현된 기능이 정상 작동되는지 테스트     
 
-검증할 전략을 옵션으로 입력
+- 검증할 전략을 옵션으로 입력  
 
-```
-python -m tester --strategies ST02,ST01
-```
+    `python -m tester --strategies ST02,ST01`  
+    `python -m run --strategies ST01`  
 
-```
-python -m run --strategies ST01
-```
 
-- [example] 결과 해석
+- (example) 결과 해석
  
     - 5가지 단위 테스트 중 1 fail, 1 error 발생     
     ```

--- a/README.md
+++ b/README.md
@@ -16,10 +16,7 @@
 
 - 코드 수정 후 main branch로 pull request
 
-## File Structure
-
-**굵게** 칠해진 곳은 아직 코딩중입니다.. :(
-
+## File Structure  
 ### input
   
 ```
@@ -134,9 +131,12 @@ ST00.json 하이퍼파라미터는 아래 파일들을 참고해서 수정할 �
 
 Server의 디렉토리 구조에서 input과 같은 수준에 위치하면 됩니다.
 
-- input
-- code
-- new_baseline_code
+```
+root/  
+├── input/  
+├── code/  
+└── odqa_baseline_code/  
+```
 
 ### Usage: Train   
   

--- a/README.md
+++ b/README.md
@@ -146,13 +146,16 @@ root/
 `python -m run --strategies ST01,ST02 --run_cnt 3`   
   
 #### Train result  
-  
-- input
-    - checkpoint
-        -ST02_95_temp
-            -checkpoint...
-        - nbest_predictions_valid.json
-        - predictions_valid.json
+
+```
+input/  
+└── checkpoint/  
+    ├── ST02_temp_95/
+    │   ├── checkpoint-500/
+    │   └── ...
+    ├── nbest_predictions_valid.json
+    └── predictions_valid.json
+```
 
 ### Usage: Predict
 
@@ -161,13 +164,14 @@ root/
   
 #### Predict result  
  
-- input
-    - checkpoint
-        -ST01
-            - nbest_predictions_test.json
-            - predictions_test.json
-
-
+```
+input/  
+└── checkpoint/  
+    └── ST01/
+        ├── nbest_predictions_test.json
+        └── predictions_test.json
+```
+  
 단일 실행도 가능합니다.
   
 ## TDD

--- a/predict.py
+++ b/predict.py
@@ -1,9 +1,7 @@
 import os.path as p
 
 from tools import update_args
-from trainer_qa import QuestionAnsweringTrainer
-from transformers import DataCollatorWithPadding
-from prepare import prepare_dataset, preprocess_dataset, get_reader_model, compute_metrics, get_retriever
+from prepare import get_dataset, get_reader, get_retriever
 
 
 def predict(args):
@@ -14,39 +12,24 @@ def predict(args):
     for idx, strategy in enumerate(strategies):
         args = update_args(args, strategy)  # auto add args.save_path, args.base_path
         args.strategy = strategy
-        args.train.do_predict = True
         args.train.output_dir = p.join(args.path.checkpoint, strategy)
 
-        datasets = prepare_dataset(args, is_train=False)
-        model, tokenizer = get_reader_model(args)
-
+        datasets = get_dataset(args, is_train=False)
         retriever = get_retriever(args)
-        retriever.get_sparse_embedding()
+        reader = get_reader(args, datasets)
 
         datasets = retriever.retrieve_pipeline(args, datasets["validation"])
-        eval_dataset, post_processing_function = preprocess_dataset(args, datasets, tokenizer, is_train=False)
+        reader.set_dataset(datasets, is_run=False)
 
-        data_collator = DataCollatorWithPadding(tokenizer, pad_to_multiple_of=8 if args.train.fp16 else None)
+        trainer = reader.get_trainer()
 
-        trainer = QuestionAnsweringTrainer(
-            model=model,
-            args=args.train,  # training_args
-            custom_args=args,
-            train_dataset=None,
-            eval_dataset=eval_dataset,
-            eval_examples=datasets["validation"],
-            tokenizer=tokenizer,
-            data_collator=data_collator,
-            post_process_function=post_processing_function,
-            compute_metrics=compute_metrics,
-        )
-
-        trainer.predict(test_dataset=eval_dataset, test_examples=datasets["validation"])
+        trainer.predict(test_dataset=reader.eval_dataset, test_examples=datasets["validation"])
 
 
 if __name__ == "__main__":
     from tools import get_args
 
     args = get_args()
+    args.train.do_predict = True
 
     predict(args)

--- a/prepare.py
+++ b/prepare.py
@@ -1,6 +1,6 @@
 import os.path as p
 
-from reader import DPRReader
+from reader import DprReader
 from retrieval.sparse import SparseRetrieval
 from tokenization_kobert import KoBertTokenizer
 from datasets import load_from_disk, load_dataset, load_metric
@@ -9,7 +9,7 @@ from transformers import AutoConfig, AutoModelForQuestionAnswering, AutoTokenize
 
 metric = load_metric("squad")
 
-READER = {"DPR": DPRReader}
+READER = {"DPR": DprReader}
 
 
 def get_retriever(args):
@@ -39,7 +39,7 @@ def get_retriever(args):
     return retriever
 
 
-def get_reader_model(args, datasets):
+def get_reader(args, datasets):
     """
     Get pretrained MRC-Reader model and tokenizer.
     If model setting is KoBERT, then load tokenizer from public KoBERT Tokenizer.
@@ -75,7 +75,7 @@ def get_reader_model(args, datasets):
     return reader
 
 
-def prepare_dataset(args, is_train=True):
+def get_dataset(args, is_train=True):
     """
     Load dataset from dataset path in disk.
 

--- a/reader/__init__.py
+++ b/reader/__init__.py
@@ -1,1 +1,1 @@
-from .reader_base import BaseReader as DPRReader
+from .base_reader import BaseReader, DprReader


### PR DESCRIPTION
이전 건모님 리팩토링과 비교하여
1. README.md 수정하였습니다. (현재 코드 반영)
2. reader 쪽 코드 및 `prepare.py`에서 변수명/메소드명의 패턴이 통일되도록 수정하였습니다.
3. BaseReader에서 DprReader를 분리하여 상속하였습니다. (이 부분 코드 분리 필요할 경우 반영하겠습니다)
4. `predict.py` 실행되지 않는 버그 있어 해당 부분 수정하였습니다.
    - 이를 위해 `BaseReader`에 `set_dataset()` 메소드를 추가하여 이 메소드를 통해 데이터를 불러오는 방향으로 수정하였습니다.
    - `set_dataset()`은 `is_run` 변수가 True면 train dataset(train+valid), False이면 test dataset을 불러옵니다.


일단 코드는 정상적으로 돌아가는 상태인데, 개인적으로 생각하고있는 문제가 몇 가지 있습니다.

1. predict모듈 실행 시 prediction 결과가 alias/seed가 없는 디렉토리에 저장됩니다.
    - 예) `ST01_base_95`로 prediction => `ST01` directory에 저장
    - 제가 보기엔 의도적으로 이렇게 설계된 것 같은데 맞나요? 그런데 제 생각엔 ST01_base_95 폴더에 직접 저장하는게 좋을 것 같은데 문제점이 뭐가 있을까요?

2. `retrieve_pipeline()` 함수 때문에 뭔가 동작이 난잡해지는 느낌입니다.
    - `run.py`의 30-35번째줄, `predict.py`의 17-22번째줄에 해당되는 내용입니다.
    - 현재 구조가 dataset(train, valid)을 통째로 불러와서 
	    1) reader에 넣어주고 (train, valid 속성이 둘 다 있지만 추후 train용으로만 사용)
	    2) `retriever.retrieve.pipeline()`에 valid만 넣어줍니다.
    - 이 구조가 아무리 봐도 이상한 것 같습니다.. `retrieve.retrieve_pipeline`이 꼭 `retriever`에 있어야하는지가 궁금해요.
    - 아직 `retrieve_pipeline`의 동작을 명확히 알지 못해서 관련 내용 수정 못했습니다.
    - 내일 일어나서 일단 수정해보겠습니다. 그전에 관련 의견 있으시면 의견 부탁드립니다!