### PR TITLE
<fix> integrate subset of retriever code & fill missing top-k parameter

### DIFF
--- a/config/model_args.py
+++ b/config/model_args.py
@@ -13,7 +13,7 @@ class ModelArguments:
         metadata={"help": "Reader Backbone, Path to pretrained model or model identifier from huggingface.co/models"},
     )
 
-    retriever_name: str = field(default="tfidf", metadata={"help": "this args used in tools/get_retriever"})
+    retriever_name: str = field(default="TFIDF", metadata={"help": "this args used in tools/get_retriever"})
     reader_name: str = field(default="DPR")
 
     config_name: Optional[str] = field(

--- a/config/retriever_args.py
+++ b/config/retriever_args.py
@@ -1,0 +1,12 @@
+from typing import Optional
+from dataclasses import dataclass, field
+
+
+@dataclass
+class RetrievalTrainingArguments:
+    """
+    Arguments pertaining to what data we are going to input our model for training and eval.
+    """
+
+    dataset_name_a: Optional[str] = field(default="train_dataset", metadata={"help": "The name of the dataset to use."})
+    topk: Optional[int] = field(default=3)

--- a/prepare.py
+++ b/prepare.py
@@ -2,7 +2,7 @@ import os.path as p
 
 from reader import DprReader
 from retrieval.dense import DprRetrieval
-from retrieval.sparse import TfidfRetrieval
+from retrieval.sparse import TfidfRetrieval, BM25Retrieval
 from tokenization_kobert import KoBertTokenizer
 from datasets import load_from_disk, load_dataset, load_metric
 from transformers import AutoConfig, AutoModelForQuestionAnswering, AutoTokenizer
@@ -11,7 +11,7 @@ from transformers import AutoConfig, AutoModelForQuestionAnswering, AutoTokenize
 metric = load_metric("squad")
 
 
-RETRIEVER = {"TFIDF": TfidfRetrieval, "DPR": DprRetrieval}
+RETRIEVER = {"TFIDF": TfidfRetrieval, "DPR": DprRetrieval, "BM25": BM25Retrieval}
 READER = {"DPR": DprReader}
 
 
@@ -19,17 +19,17 @@ def get_retriever(args):
     """
     Get appropriate retriever.
 
-    AVAILABLE OPTIONS(2021.05.02)
+    AVAILABLE OPTIONS(2021.05.05)
     - Term-based
         - TF-IDF : use konlpy-Mecab for word tokenization.
-        - TODO : BM-25
+        - BM-25
     - Vector Embedding
         - Sparse
-        - TODO : Dense
+        - Dense
     Need more retriever and retriever options.
 
     :param args
-        - model.retriever_name : [tfidf]
+        - model.retriever_name : [TFIDF, DPR, BM25]
     :return: Retriever which contains embedded vector(+indexer if faiss is built).
     """
 

--- a/run.py
+++ b/run.py
@@ -31,7 +31,7 @@ def train_reader(args):
         retriever = get_retriever(args)
         reader = get_reader(args, datasets)
 
-        datasets = retriever.retrieve(datasets["validation"])
+        datasets = retriever.retrieve(datasets["validation"], args.retriever.topk)
         reader.set_dataset(datasets, is_run=True)
 
         trainer = reader.get_trainer()

--- a/tools.py
+++ b/tools.py
@@ -3,9 +3,10 @@ import json
 import argparse
 import os.path as p
 
-from config.data_args import DataTrainingArguments
 from config.train_args import TrainArguments
 from config.model_args import ModelArguments
+from config.data_args import DataTrainingArguments
+from config.retriever_args import RetrievalTrainingArguments
 
 from transformers import HfArgumentParser, TrainingArguments
 
@@ -78,7 +79,7 @@ def update_args(args, strategy):
         temp = json.load(f)
 
     args.alias = temp["alias"]
-    for arg_type in ["model", "data", "train"]:
+    for arg_type in ["model", "data", "train", "retriever"]:
         temp_type = getattr(args, arg_type)
         for k, v in temp[arg_type].items():
             setattr(temp_type, k, v)
@@ -133,13 +134,15 @@ def get_args():
     if args.run_cnt > len(SEEDS):
         raise ValueError("SEEDS를 직접 입력하거나 SEEDS Default 값을 늘려주세요. ")
 
-    parser = HfArgumentParser((ModelArguments, DataTrainingArguments, TrainArguments))
-    model_args, data_args, train_args = parser.parse_args_into_dataclasses(args=[])
+    parser = HfArgumentParser((ModelArguments, DataTrainingArguments, TrainArguments, RetrievalTrainingArguments))
+    model_args, data_args, train_args, retriever_args = parser.parse_args_into_dataclasses(args=[])
     training_args = TrainingArguments(output_dir=args.path.checkpoint)
 
     args.model = model_args
     args.data = data_args
     args.train = training_args
+    args.retriever = retriever_args
+
     return args
 
 


### PR DESCRIPTION
- 지영님 branch에서 추가된 retrieval argument
- run.py에서 누락된 top-k 관련 파라미터 추가
  - config의 ST.json에서 retriever 추가 필요
 
종헌님이 이미 고치시고 commit만 남겨두고 있으신것 같지만 저도 돌려보느라 고쳐놓은 부분들 올렸습니다. 아직 지영님 브랜치 파일 정리가 다 안된것같아 merge해도 무리 없어 보이는 부분들만 제 브랜치에 적용시키고 종헌님 브랜치로 pull request 보냅니다!

**BM 25 이슈는 아직 top-k개를 뽑아오지 못해서 정확도가 많이 낮은 문제도 있던것 같습니다.**

<img width="323" alt="Screen Shot 2021-05-05 at 7 25 50 AM" src="https://user-images.githubusercontent.com/26772420/117077478-2778bb00-ad73-11eb-81a2-5dcec50c34bd.png">
<img width="321" alt="Screen Shot 2021-05-05 at 7 25 54 AM" src="https://user-images.githubusercontent.com/26772420/117077484-29db1500-ad73-11eb-8355-f5ebfb8c7d51.png">

위의 그래프는 기존 run 코드에서 건모님과 지영님이 구현해두신 top-k 샘플링 적용하여 query당 5개 지문 뽑아왔을 때의 EM입니다.
top-1 sampling에서는 BM25가 EM 6% 가량으로 더 낮게 나왔지만, 샘플링 수를 늘리자 13%가량으로 비슷해졌습니다. F-1은 오히려 근소하게 역전했습니다.