### PR TITLE
<fix> Improve BM25 with hyper-parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ ST00.json 하이퍼파라미터는 아래 파일들을 참고해서 수정할 �
         "logging_steps": 100,
         "overwrite_output_dir": true,
         "report_to": ["wandb"]
-    }
+    },
     "retriever": {
         "retrain": false,
         "dense_train_dataset": "train_dataset",
@@ -171,7 +171,7 @@ input/
 - Retriver 모델은 학습이 완료된 이후로는 결과가 불변이기 때문에 run_cnt 값을 1로 설정해주시면 됩니다.
 - retrain 인자를 사용해서 재학습을 진행할 수 있습니다.
 
-`python -m run_retriver --strategies ST01,ST02,ST03,ST04 --run_cnt 1`
+`python -m run_retrieval --strategies ST01,ST02,ST03,ST04 --run_cnt 1`
 
 #### RETRIVER Result
 

--- a/retrieval/sparse/bm25.py
+++ b/retrieval/sparse/bm25.py
@@ -9,12 +9,12 @@ from retrieval.sparse import SparseRetrieval
 
 
 class BM25Retrieval(SparseRetrieval):
-    def __init__(self, args, b=0.75, k1=1.2):
+    def __init__(self, args, b=0.01, k1=0.1)
         super().__init__(args)
         mecab = Mecab()
-        self.b = b  # 0일 수록 문서 길이의 중요도가 낮아진다.
-        self.k1 = k1  # TF, TF decay
-        self.encoder = TfidfVectorizer(tokenizer=mecab.morphs, ngram_range=(1, 2), max_features=50000)
+        self.b = b  # 0일 수록 문서 길이의 중요도가 낮아진다. 일반적으로 0.75 사용.
+        self.k1 = k1  # TF의 saturation을 결정하는 요소. 어떤 토큰이 한 번 더 등장했을 때 이전에 비해 점수를 얼마나 높여주어야 하는가를 결정. (1.2~2.0을 사용하는 것이 일반적)
+        self.encoder = TfidfVectorizer(tokenizer=mecab.morphs, ngram_range=(1, 2))
 
         self.avdl = None
         self.p_embedding = None

--- a/retrieval/sparse/bm25.py
+++ b/retrieval/sparse/bm25.py
@@ -9,7 +9,7 @@ from retrieval.sparse import SparseRetrieval
 
 
 class BM25Retrieval(SparseRetrieval):
-    def __init__(self, args, b=0.01, k1=0.1)
+    def __init__(self, args, b=0.01, k1=0.1):
         super().__init__(args)
         mecab = Mecab()
         self.b = b  # 0일 수록 문서 길이의 중요도가 낮아진다. 일반적으로 0.75 사용.
@@ -51,8 +51,10 @@ class BM25Retrieval(SparseRetrieval):
         doc_scores = []
         doc_indices = []
 
+        p_embedding = self.p_embedding.tocsc()
+
         for query_vec in tqdm.tqdm(query_vecs):
-            p_emb_for_q = self.p_embedding.tocsc()[:, query_vec.indices]
+            p_emb_for_q = p_embedding.tocsc()[:, query_vec.indices]
             denom = p_emb_for_q + (k1 * (1 - b + b * len_p / avdl))[:, None]
 
             # idf(t) = log [ n / df(t) ] + 1 in sklearn, so it need to be converted

--- a/retrieval/sparse/tfidf.py
+++ b/retrieval/sparse/tfidf.py
@@ -10,7 +10,7 @@ class TfidfRetrieval(SparseRetrieval):
         super().__init__(args)
 
         mecab = Mecab()
-        self.encoder = TfidfVectorizer(tokenizer=mecab.morphs, ngram_range=(1, 2), max_features=50000)
+        self.encoder = TfidfVectorizer(tokenizer=mecab.morphs, ngram_range=(1, 2))
         self.p_embedding = None
 
     def _exec_embedding(self):


### PR DESCRIPTION
- Corrected typos in README.md
- Adjusted hyper-parameters in BM25 and TFIDF
  - TFIDF: `max_features` 50000 -> None
  - BM25: `max_features` 50000 -> None, `b` 0.75 -> 0.01, `k1` 1.2 -> 0.1 