### PR TITLE
<fix> Fixed create_dataset, run_retrieval

### DIFF
--- a/run_retrieval.py
+++ b/run_retrieval.py
@@ -7,7 +7,8 @@ import numpy as np
 import matplotlib.pyplot as plt
 from transformers import set_seed
 
-from tools import update_args
+from tools import get_args, update_args
+from fuzzywuzzy import fuzz
 from prepare import get_dataset, get_retriever
 
 
@@ -92,7 +93,8 @@ def train_retriever(args):
             topk_dataset = valid_datasets["validation"][fancy_index[0]]
 
             for real, pred in zip(topk_dataset["original_context"], topk_dataset["context"]):
-                if real == pred:
+                # if two texts overlaps more than 95%,
+                if fuzz.ratio(real, pred) > 95:
                     cur_cnt += 1
 
             topk_acc = cur_cnt / tot_cnt
@@ -104,7 +106,6 @@ def train_retriever(args):
 
 
 if __name__ == "__main__":
-    from tools import get_args
 
     args = get_args()
     train_retriever(args)


### PR DESCRIPTION
Changed dataset structure and context comparison logic (added fuzzywuzzy library)

논의했던 대로 데이터셋 구조를 바꿔서, 한 question 당 여러 context가 할당되도록 했습니다. 그리고 retrieval_labels에 정답 위치를 표시해주는 one-hot vector를 리스트로 넣었습니다. (나머지는 혹시나 필요할지 몰라서 유지해둔 feature들입니다.)

`Dataset({
    features: ['answers', 'contexts', 'document_id', 'id', 'original_context', 'question', 'retrieval_labels']
})`

topk를 16으로 두었을 때, 데이터 중복을 피하기 위해 18개를 뽑아온 뒤 이 중 정답과 겹치지 않는 15개를 뽑고, 정답을 랜덤하게 삽입합니다.

성익님도 EDA에서 언급해주셨었는데, 정답 데이터가 text가 조금씩만 다르게 wiki에 포함되어 있어 정답이라고 인식하지 못하는 버그가 있었습니다. 그래서 `fuzzywuzzy` 라이브러리를 설치해서 95% 이상 겹치면 정답으로 인식해서 유사 context를 뽑을 때 제외할 수 있도록 개선했습니다.

`pip install fuzzywuzzy[speedup]`로 설치해 주시면 됩니다. run_retrieval에서 정답 context를 인식하는 방식도 함께 개선했습니다.


데이터셋 예시:
```
{'answers': {'answer_start': [235], 'text': ['하원']},
 'contexts': ['이하의 국가들은 의회에서 행정부 수반을 선출한다는 점에서 내각제와 닮았다. 그리고 이들 국가들 중 상당수는 행정부 수반이 의회해산권을 갖고, 의회는 내각불신임권을 갖는데 이점 역시 내각제와 닮았다. 하지만 내각제와 달리 의회에서 선출되는 자는 행정부 수반의 지위 뿐만 아니라 국가 원수의 지위도 가진다. 그래서 의회에서 선출되는 자의 직위는 총리가 아니라, 대통령이다. 이처럼 1인이 행정부 수반과 국가 원수의 지위를 겸한다는 점에서 대통령중심제와 닮았다. 이상과 같은 이유로 이들 국가들의 정부 형태는 대통령제와 내각제의 절충형이지만, 행정 권한이 2인에게로 분리되어 있지 않으므로 이원집정부제는 아니다.\n\n \n* 나우루\n* 남아프리카 공화국\n* 마셜 제도\n* 마카오\n* 미얀마\n* 미크로네시아 연방\n* 보츠와나\n* 산마리노\n* 수리남\n* 키리바시\n* 홍콩',
  '국회에 관해 규정하는 헌법 제4장의 첫 조문이다.\n\n본조에서 말하는 "국권"이란 국가가 갖는 지배권을 포괄적으로 나타내는 국가 권력, 곧 국가의 통치권을 의미한다. 국권은 일반적으로 입법권·행정권·사법권의 3권으로 분류되지만, 그 중에서도 주권자인 국민의 의사를 직접 반영하는 기관으로서 국회를 "최고 기관"으로 규정한 것이다. 다만, 최고 기관이라 해서 타 기관의 감시와 통제를 받지 않는 것은 아니며 권력 분립 원칙에 따라 국회에 대한 행정권, 사법권의 견제를 받는다.\n\n또한 일본 전체 국민을 대표하는 기관을 국회로 규정함으로써, 국회는 일본의 유일한 입법 기관의 지위를 가지고 있다. 일본 제국 헌법 하에서 입법권은 천황의 권한에 속했으며, 제국의회는 천황의 입법 행위를 보좌하는 기관에 불과했다.\n\n여기서 "유일한 입법 기관"의 의미로는 다음과 같은 해석이 있다.\n* 국회 중심 입법 원칙 : 국회가 국가의 입법권을 독점한다는 원칙\n* 국회 단독 입법 원칙 : 국회의 입법은 다른 기관의 간섭 없이 이루어진다는 원칙\n\n또한 국회의 입법에 벗어나지 않는 범위 내에서 행정 기관은 정령 등의 규칙 제정권을 가지며(헌법 제73조 제6호), 최고재판소는 소송에 관한 절차, 변호사 및 재판소에 관한 내부 규율 및 사법 사무 처리에 관한 사항에 대한 규칙 제정권(헌법 제77조 제1항)을 가진다.',
  "미국의 외교정책의 수립과 이행에 대한 주된 책임을 대통령이 지게 되어 있으나, 의회도 이에 대해 강한 통제력을 발휘할 수 있다. 우선 의회는 전쟁을 선포할 수 있는 권한이 있다. 하원은 대통령의 외교정책 수행에 필요한 예산에 대해 강한 통제력을 가지고 있으며, 상원도 재원에 대한 통제가 가능하다. 특히 상원의 경우에는 고급 외무 관리의 임명에 대한 통제력을 가지고 있을 뿐만 아니라, 미국이 체결하는 모든 조약에 대한 비준권을 가지고 있다. 의회의 이와 같은 제재 권한은 행정부와 의회의 갈등을 초래하는 요소로 작용한다. 에드워드 코르윈(Edward Samuel Corwin) 교수는 미국의 정치체계가 외교정책에 있어서 행정부와 의회 간의 투쟁을 초래한다고 지적한 바 있다. 그 좋은 예로서는 상원이 국제연맹 헌장의 비준을 거부한 사실을 들 수 있다. 의회와 행정부간에는 긴밀한 협조가 이루어지고 있다. 유엔헌장 비준 당시의 의회와 행정부 간의 긴밀한 협조는 너무나 유명하다. 그러나 이러한 협동외교는 한국에서 흔히 사용되고 있는 '초당외교'라는 말과는 엄격히 구분되어야 한다. 베트남 전쟁으로 말미암아 파생된 행정부와 의회 간의 갈등은 심각한 형편이었다. 그러나 의회가 대통령에 가하는 압력은 행정부의 독주를 견제하는 동시에 건전한 방향의 미국 대외정책을 모색하고 있다. 의회는 국민의 대표기구로서 국민의 의사와 직결돼 있다. 따라서 대외정책의 수립이나 이행 과정에도 항상 의회를 '문제아'로 취급하거나, 또는 그러한 범주 내에 의회의 기능을 이해해서는 안 된다.",
  '내각(內閣, cabinet)은 행정부의 주요 각료들로 구성되는 국가의 주요기관이다.\n\n의원내각제에서 내각은 수상과 여러 장관으로 조직되는 합의체로, 국가의 행정권을 담당하고 국회에 대한 연대책임을 갖는다. 의원내각제에 있어서 내각은 국가행정의 최고기관인 한편 국민이 구성시키는 의회에 의하여 철저히 견제되어 의회민주주의 체제를 이룬다.\n\n그 직접적 유래는 영국에서 국왕의 정치를 자문하던 추밀원에서 찾을 수 있다. 특히 내각은 추밀원의 일개 회의에서 시작하였다가 권한이 집중되어 분리된 기관으로, 이후 국왕의 실권이 사라지고 일명 웨스트민스터 시스템으로 불리는 의원내각제가 성립하면서 의회에 의한 민주적 행정부를 이루게 되었다.\n\n한편 국가원수에게 대부분의 권력이 집중되는 대통령중심제와 군주제에서 내각은 원칙적으로 의결권이 없거나 의결의 구속력이 없는 보좌기관에 불과한 경우가 많다.(예: 대한민국의 국무회의)\n\n대한민국은 국무회의가 내각에 속하며 권한이 대통령에 비해 제한적이다. 과거 왕조시대 때는 고려시대의 중서문하성, 중추원, 육부 또는 조선시대의 의정부와 육조가 내각과 비슷한 성향을 지니고 있었다.',
  '리히텐슈타인의 의회주의는 1862년 헌법과 함께 시작되었다고 할 수 있다. 이렇게 생긴 의회는 대부분이 국민의 자유선거로 선출되어 국민을 대표하는 최초의 의회였다. 의원정수는 15명으로 줄었다. 그 중 3명은 제후가 임명하고, 나머지 12명은 국민이 간접선거를 통해 선출했다. 선거를 위해 우선 지역공동체에서 남성 100인당 2인의 선거인단을 선출하고, 선거인단 총회에서 의원을 선출했다. 의회는 국가기능에 영향을 미치는 가장 중요한 기관은 아니었지만, 가장 중요한 기관들 중에 하나가 되었다. 의회는 국제조약과 세금인상법의 입법에 영향력을 행사했고, 행정기관을 견제하고 징병법안에 동의할 수 있는 권한을 가지게 되었다.',
  "통일주체국민회의는 1972년 10월 17일 10월 유신으로 제4공화국이 출범하면서 헌법에 따라 구성된 간접민주주의 기관이다. 가장 중요한 기능은 유신헌법의 핵심인 대통령의 간접 선거 기능을 담당한 것이다. 1973년 8월부터 약칭은 국민회의로 정해졌다. 국민회의는 전국의 각 지역구에서 국민의 직접 선거로 선출된 대의원들로 구성되었는데, 통일주체국민회의 대의원들은 비공식적으로 통대라는 약칭으로 불리었다.\n\n유신헌법 제3장에 의하면 통일주체국민회의는 국가의 정상기관(頂上機關)이자 주권적 수임 기관으로서, 조국의 평화적 통일을 촉진하기 위한 국민의 총의가 모인 곳이다. 따라서 6년의 임기를 가진 이 기관의 대의원은 국민의 직접선거로 선출되며, 대통령을 선출하고 국회의원 정수의 3분의 1(유신정우회)을 선출하며, 국회의 헌법 개정안을 최종 의결하고 통일 정책을 심의하는 기능을 갖고 있다.\n\n신민당은 제9대 대통령 선거를 앞두고 정당이 대통령 후보를 지명하고, 대의원 선거에 출마하는 대의원 후보들은 지지하는 대통령 후보를 정하고 선거를 치르게 하는 미국의 대통령 선거인 선거 방식의 통일주체국민회의 대의원 선거법 개정안을 내기도 하였으나 이루어지지 않았다. \n\n사실상  박정희 대통령의 거수기 노릇을 하던 이 기관은 1979년 10월 26일 그가 암살되자 그 후임 대통령인 최규하와 전두환을 형식적으로 선출해주는 역할을 맡은 뒤, 이듬해 제5공화국 헌법 발효와 함께 해체되었다. 그 후 대통령간선제를 담당하는 기관은 대통령 선거인단으로 교체되었으며, 사무처와 인적구성 및 대통령 직속 통일 관련 기구로써의 역할은 '평화통일정책자문회의'를 거쳐 민주평화통일자문회의로 이어지고 있다.",
  "통일주체국민회의는 1972년 10월 17일 10월 유신으로 제4공화국이 출범하면서 헌법에 따라 구성된 간접민주주의 기관이다. 가장 중요한 기능은 유신헌법의 핵심인 대통령의 간접 선거 기능을 담당한 것이다. 1973년 8월부터 약칭은 국민회의로 정해졌다. 국민회의는 전국의 각 지역구에서 국민의 직접 선거로 선출된 대의원들로 구성되었는데, 통일주체국민회의 대의원들은 비공식적으로 통대라는 약칭으로 불리었다.\\n\\n유신헌법 제3장에 의하면 통일주체국민회의는 국가의 정상기관(頂上機關)이자 주권적 수임 기관으로서, 조국의 평화적 통일을 촉진하기 위한 국민의 총의가 모인 곳이다. 따라서 6년의 임기를 가진 이 기관의 대의원은 국민의 직접선거로 선출되며, 대통령을 선출하고 국회의원 정수의 3분의 1(유신정우회)을 선출하며, 국회의 헌법 개정안을 최종 의결하고 통일 정책을 심의하는 기능을 갖고 있다.\\n\\n신민당은 제9대 대통령 선거를 앞두고 정당이 대통령 후보를 지명하고, 대의원 선거에 출마하는 대의원 후보들은 지지하는 대통령 후보를 정하고 선거를 치르게 하는 미국의 대통령 선거인 선거 방식의 통일주체국민회의 대의원 선거법 개정안을 내기도 하였으나 이루어지지 않았다. \\n\\n사실상 박정희 대통령의 거수기 노릇을 하던 이 기관은 1979년 10월 26일 그가 암살되자 그 후임 대통령인 최규하와 전두환을 형식적으로 선출해주는 역할을 맡은 뒤, 이듬해 제5공화국 헌법 발효와 함께 해체되었다. 그 후 대통령간선제를 담당하는 기관은 대통령 선거인단으로 교체되었으며, 사무처와 인적구성 및 대통령 직속 통일 관련 기구로써의 역할은 '평화통일정책자문회의'를 거쳐 민주평화통일자문회의로 이어지고 있다.",
  '직권남용죄(職權濫用罪)는 공무원이 직권을 남용하여 사람으로 하여금 의무 없는 일을 행하게 하거나 사람의 권리행사를 방해하는 죄이다. 5년 이하의 징역과 10년 이하의 자격정지 또는 1천만원 이하의 벌금에 처한다(대한민국 형법 제123조). 공무원이 그 직권을 남용하여 국가 또는 지방자치단체 작용의 엄정(嚴正)을 해하였다는 데에 본죄의 특질이 있으며 헌법적으로 주권자인 국민에 대해 봉사자인 공무원이 갑질하는 것을 예방하여 국민주권주의를 기본으로 하는 헌정질서 수호를 목적으로 한다. 하지만 오랜 비민주적인 통치 권력이 집권하던 시기에 공무원에 의한 전횡적인 횡포가 잇따르자 1988년 6월 항쟁의 결실로 대통령 선거 직선제 등 민주화 개헌을 하면서 행정부 견제 수단으로 헌법재판소를 신설하면서 국민이 헌법재판소에 직접 \'공권력 행사나 불행사에 의한 기본권 침해가 있은 때\'에 헌법소원을 청구할 수 있게 하였는데 그 대상이 직권남용과 직무유기 범죄가 되는 내용이다.\n\n\'직권의 남용\'이란 형식적으로 일반직무권한에 속하는 사항에 대하여 자기의 직권을 남용하여 행사하는 것을 말한다. 의무없는 일을 하게 하거나 권리행사를 방해하는 것으로서 예컨대 부당하게 과중한 세금을 부과하여 납부케 하는 경우도 포함한다. 공무원이 직권을 남용하여 폭행·협박으로써 사람의 권리행사를 방해한 경우에는 본죄가 아니라 324조의 죄를 구성하며 그 처벌은 135조의 규정에 의하여 그 형의 2분의 1까지 가중한다. \n\n그러나 현실적으로 적용하여 처벌하는 것은 거의 없다. 특히 범죄 구성요건으로 "강제성이 있어야 한다"고 하는데 마치 하여야 하는 것 처럼 지시하고선 추후에 강제성이 없어 직권남용이 아니라고 하는 것은 모순이 있고 무엇보다 검사의 독점적 기소 권한의 폐단 성격이 짙으며 사회적인 화제가 될 때 기소가 이루어진다.',
  '국가판무관부(라이히코미사리아트. 복수형 라이히코미사리아테)는 독일어로 행정부의 국가판무관(라이히코미사리아)이 수장인 행정기관을 이르는 말이다. 공공인프라, 토지계획, 인종청소 등의 행정 업무로의 국가판무관부라는 용어는 독일 제국 및 나치 독일 시기 전반에 걸쳐 존재했지만, 통상적으로는 제2차 세계 대전 시기 나치 독일이 점령한 국가를 준식민지로 삼기 위해 계획한 일종의 총독부를 뜻한다. 이 국가판무관부은 법적으로는 독일국의 외부의 지역이었으나, 실질적으로는 아돌프 히틀러가 직접 임명한 주지사급에 해당한 최고행정부 국가판무관이 통치하는 사실상의 제국 내 영토였다.  또한 국가판무관부 산하에 총괄판무관부를 두어 행정을 관리하였다.\n\n이 행정기관은 여러가지 이유로 도입하게 되었다. 서유럽과 북유럽에 설립되거나 계획된 국가판무관부는 나치 독일이 전쟁 전 외부 영토였던 독일어권을 편입하면서 영토로 통합하기 전 과도기적 기구로 운용했다.  동유럽 지역은 독일인 정착지, 천연자원 착취 등의 레반스라움을 위한 식민주의, 제국주의적 성격으로 설립되었다.  \n\n행정 기관의 점령지 정책도 이 2가지로 나눌 수 있었다. 독일이 점령한 대부분의 지역처럼 지역 행정부와 관료들은 독일의 감독 아래 중-하급의 일상적인 업무를 계속 수행했다. 전쟁 기간 서유럽과 북유럽은 기존에 존재했던 행정부 구조를 유지한 채로 국가판무관부를 수립했으나, 동유럽은 완전히 새로운 행정 구조를 만들었다. \n\n국가판무관부의 모든 지역은 나중에는 대게르만 제국(Grossgermanisches Reich)로 통합될 예정이었으며, 이 제국의 영역은 북해부터 우랄산맥까지의 영역을 포함한 광대한 지역이었다',
  '수도(首都)는 한 국가의 정치, 행정의 중심이 되는 도시를 말한다. 수도에는 대부분 중앙정부가 소재해, 국가원수 등 국가의 최고 지도자가 거점으로 두는 도시이다. 다만 중앙 정부의 소재와는 별도로 그 나라의 상징적 존재로 인정되고 있는 도시가 수도로 여겨지기도 한다.\n\n국가에 따라서는 여러 개의 수도가 있기도 하며, 수도에 실제 행정부가 위치하지 않거나, 주요 국가 기관이 여러 도시에 나뉘어 위치하기도 한다. 예를 들어 남아프리카공화국의 행정부는 프리토리아에, 입법부는 케이프타운에, 사법부는 블룸폰테인에 있다. 네덜란드의 헌법은 암스테르담을 수도로서 명시하고 있으나, 실제 정부와 최고 법원은 헤이그에 위치해 있다.',
  "1957년 말부터 1958년 초에 걸쳐 미국 국가항공자문위원회 (NACA)는 그때까지 자신들이 한 일과 같은 역할을 맡은 비군사적 기관의 신설에 대한 검토를 시작했다. 또 그 개념을 정밀 조사하기 위해서 몇 개의 위원회를 창설했다. 1958년 1월 12일, NACA는 가이포드 스테버(Guyford Stever)를 의장으로 하는 '우주 기술 특별 위원회' 를 설립했다. 이 위원회는, 제2차 세계 대전 후에 미국 시민권을 획득한 베르너 폰 브라운 박사를 리더로 하는 미국 육군 탄도 미사일국의 우주 로켓 개발 그룹에서 제안된, 거대 로켓 개발 계획을 자문하는 임무도 띠고 있었다.\n\n1958년 1월 14일, NACA 책임자 휴 드라이덴은 '우주 기술을 위한 국가적 조사 계획'을 발표해, 이하와 같이 말했다.\n\n미국의 위신 및 군사적 필요성의 양면에서 생각하면, 이번 도전(스푸트니크)에 휩쓸린 우주 정복을 위한 조사 및 개발의 계획을 정력적으로 추진하는 것은 긴급하고 중요한 과제이다.(중략) 그 때문에, 비군사적인 국가 기관에 의해서 과학적인 조사를 해야 한다는 제안이 이루어졌다.(중략) NACA는 우주 개발 기술의 주도권을 취해 그 성과를 급속히 확대해 연장할 수 있는 능력이 있다.\n\n1958년 1월 31일 오후 10시 48분 (미국 동부표준시), 미국 첫 인공위성인 익스플로러 1호가 발사되었다. 1958년 3월 5일, 대통령 직속 과학 기술 자문 위원회의 위원장 제임스 킬리안(James Killian)은 아이젠하워 대통령에게 「민간 우주 계획을 위한 조직」이라는 제목의 서신을 보내, 일정의 지연을 최소한으로 억제해 조사 계획을 확장할 수 있도록 NACA를 강화해 재편한 조직에 의한 문민 통제형의 우주 계획을 창립하는 것을 재촉했다. 동년 3월 말에 NACA는, 당시 기획 중이었던 수소와 불소를 추진제로 하는 100만 파운드(453톤, 445만 뉴턴)의 추진력을 가지는 3단 로켓의 개발 계획을 포함한, 「우주 개발에 관한 제의」라는 제목의 보고서를 발표했다.\n\n동년 4월, 아이젠하워 대통령은 의회 연설을 통해, 민간 주도의 우주 개발 기관을 신설할 의향과 미국 항공우주국 설립을 위한 예산안을 설명했다. NACA의 조사 활동 하나를 봐도, 그 규모나 진전, 관리, 운영 등에 있어서 변화가 이루어져야 했다. 7월 16일, 의회는 예산안을 승인하고, 동시에 NASA 설립을 위한 구체적인 근거가 된 '국가 항공 우주 결의'에 대해서도 약간의 언급을 했다. 그 이틀 후, 베르너 폰 브라운이 인솔하는 작업 그룹은 예비 보고서를 제출해, 현재 미국의 우주 개발은 여러 가지 기관이 따로 시행하고 있어 상호 제휴가 결핍되어 국가적 노력이 중복되어 손해가 크다는 것을 강력하게 비판했다. 스테버의 우주 개발 위원회는 브라운의 비판에 동의해, 10월에는 최종적인 초안이 제출되었다.",
  '대사(大使, 앰배서더) 또는 특명전권대사(特命全權大使)는 국가를 대표해서 외국에 파견되는 외교 사절이다. 특명전권대사는 외교 사절단 중에서 제일 높은 계급이며, 각국의 대통령, 총리 등 정상을 외교 업무 목적으로 만나기 위해 파견된다. 국제 연합 등의 국제 기관으로도 파견되고 있다. 대사는 일반적으로 강대국이나 그 나라와의 중요한 관계를 갖는 국가에 파견된다.\n\n외교 사절의 두 번째로 높은 계급은 공사 혹은 특명전권공사이고, 세 번째 높은 계급으로 변리공사(한국에서는 변리공사가 없음)와 대리공사가 있다. 대사와 공사는 직무·특권에 있어서는 같다고 생각해도 무방하다. 특명전권공사는 체류국의 정상에 대해서, 대리공사는 체류국의 외무장관에 대해서 각각 파견된다.',
  '한미 관계\n\n이명박 대통령은 이미 여러 차례 “새로운 정부에서는 한미관계를 더욱 강화하겠다”는 뜻을 밝혔고 실제로 한미관계는 더욱 강화될 것이라 보는 의견이 많았다.  이명박 대통령은 한미동맹 강화를 위해서는 미국 주도의 대량살상무기 확산방지구상(PSI)과 MD 계획에도 적극 참여해야 한다는 입장인 것으로 알려졌다. \n\n미국산 쇠고기 수입 협상 논란은 촛불집회로 비화되어 2008년 미국산 쇠고기 수입 협상 논란을 경험했다. 이때 이명박 정부는 미국과의 동맹강화를 위해 이러한 논란을 묵살하는 정책을 폈으며, 결과적으로 성공적으로 사태를 진압하여 한미관계 강화를 향한 일관된 원칙을 증명했다.\n\n이후, 2009년 미국의 새로운 오바마 행정부의 등장으로 외교관계는 일시적으로 정체되었다가, 현재는 정상회담을 통해 북핵문제에 대한 공조 및 G20 정상 회의 등에 대한 포괄적 합의를 하는 데에 이르렀다. \n\n2009년 11월 19일에는 미국의 오바마 대통령이 방한했다. 여기서 이명박 한국 대통령과 오바마 미국 대통령은 한미동맹 강화 및 한미자유무역협정 협상의 진전을 위한 노력, 북핵 문제의 그랜드 바겐 방식 공감, 아프가니스탄의 한국군 파병 문제 논의 등이 이루어졌으며,‘동맹’ 실천계획 없는 “공감”… FTA 이견 재확인|url=http://news.khan.co.kr/kh_news/khan_art_view.html?artid=200911191818365&code=910302|출판사=경향신문|저자=서의동|날짜=2009-11-19|확인날짜=2009-11-19}}</ref> 이명박 대통령이 오바마 미국 대통령에게 태권도복을 선물하는 등의 화기애애한 분위기가 연출되기도 하였다.  하지만 여기서 논의된 한미자유무역협정 자동차 부문 재협상 문제  와 아프가니스탄의 한국군 파병 문제는 대한민국 내에서 논란을 불러 일으키기도 했다.  또한 두 정상의 미묘한 의견 불일치가 있다는 의견도 있었다. \n\n2010년 6월 27일 캐나다 토론토에서 이명박 대통령과의 양자 정상회담 뒤 가진 기자회견에서 전시작전통제권을 2015년으로 연기하기로 합의했다고 발표하면서“전작권 연기 결정을 통해 한·미 양국이 기존의 안보 틀 내에서 일을 제대로 할 수 있는 적절한 시간을 줄 것”이라고 말했다. 또한 “한미동맹은 한국과 미국의 안보뿐 아니라 태평양 전체 안보의 핵심(Linchpin)이기 때문”이라고 강조했다. 오바마 대통령은 이어 “한국은 미국의 가장 친한 친구 중 하나”라고 언급했다.',
  "즉각적으로 정권을 인수받은 후 클린턴은 1993년 가족 의료 법안에 관한 대선 공약에 즉각 서명하게 된다. 본 법안은 고용인에게 종업원의 의료 문제 발생 상황시 의료 보호를 받을 수 있도록 근로 상황을 개선하는 것을 요구할 수 있도록 하는 것을 골자로 하는 보호 법안이었다.\n\n이 정책이 대중적이었던 반면, 클린턴이 대선 초기에 공약했던 군대 내 성소수자 권리 정책에 대한 명확하지 않은 태도는 보수와 진보 양측으로부터 비판을 받게 되었다. 진보 진영은 정책이 다소 실험적이라고 주장했고 보수진영은 군생활에서 별 반응을 보이지 않는 정책이라고 평가했다. 많은 토의가 있던 후 클린턴과 펜타곤은 일명 ‘묻지도 말고 대답도 하지 말라’는 정책에 합의하게 되며 그것은 오바마 대통령 때까지 유효했다.\n\n클린턴 대통령은 취임하자마자 공약대로 연방공무원 10만명 감축 지시를 내렸고, 고어 부통령에게 정부를 완전히 새롭게 재창조하기 위한 방안을 강구하도록 명령했다. 이에 따라 고어 부통령의 주도 아래 국정성과평가팀(NPR)을 설치하고 본격적인 개혁 작업에 착수했다. 당시 미국의 행정 개혁은 '정보기술을 통한 정부 재구축' 프로그램을 통해 공무원을 30만명 이상 감축하는 성과를 거뒀다. 이러한 미국 행정 개혁의 성공은 정보기술을 활용한 전자정부의 구현을 통해 이룬 결과라는 평가가 있다.",
  "즉각적으로 정권을 인수받은 후 클린턴은 1993년 가족 의료 법안에 관한 대선 공약에 즉각 서명하게 된다. 본 법안은 고용인에게 종업원의 의료 문제 발생 상황시 의료 보호를 받을 수 있도록 근로 상황을 개선하는 것을 요구할 수 있도록 하는 것을 골자로 하는 보호 법안이었다.\\n\\n이 정책이 대중적이었던 반면, 클린턴이 대선 초기에 공약했던 군대 내 성소수자 권리 정책에 대한 명확하지 않은 태도는 보수와 진보 양측으로부터 비판을 받게 되었다. 진보 진영은 정책이 다소 실험적이라고 주장했고 보수진영은 군생활에서 별 반응을 보이지 않는 정책이라고 평가했다. 많은 토의가 있던 후 클린턴과 펜타곤은 일명 ‘묻지도 말고 대답도 하지 말라’는 정책에 합의하게 되며 그것은 오바마 대통령 때까지 유효했다.\\n\\n클린턴 대통령은 취임하자마자 공약대로 연방공무원 10만명 감축 지시를 내렸고, 고어 부통령에게 정부를 완전히 새롭게 재창조하기 위한 방안을 강구하도록 명령했다. 이에 따라 고어 부통령의 주도 아래 국정성과평가팀(NPR)을 설치하고 본격적인 개혁 작업에 착수했다. 당시 미국의 행정 개혁은 '정보기술을 통한 정부 재구축' 프로그램을 통해 공무원을 30만명 이상 감축하는 성과를 거뒀다. 이러한 미국 행정 개혁의 성공은 정보기술을 활용한 전자정부의 구현을 통해 이룬 결과라는 평가가 있다.",
  '미국 상의원 또는 미국 상원(United States Senate)은 양원제인 미국 의회의 상원이다.\\n\\n미국 부통령이 상원의장이 된다. 각 주당 2명의 상원의원이 선출되어 100명의 상원의원으로 구성되어 있다. 임기는 6년이며, 2년마다 50개주 중 1/3씩 상원의원을 새로 선출하여 연방에 보낸다.\\n\\n미국 상원은 미국 하원과는 다르게 미국 대통령을 수반으로 하는 미국 연방 행정부에 각종 동의를 하는 기관이다. 하원이 세금과 경제에 대한 권한, 대통령을 포함한 대다수의 공무원을 파면할 권한을 갖고 있는 국민을 대표하는 기관인 반면 상원은 미국의 주를 대표한다. 즉 캘리포니아주, 일리노이주 같이 주 정부와 주 의회를 대표하는 기관이다. 그로 인하여 군대의 파병, 관료의 임명에 대한 동의, 외국 조약에 대한 승인 등 신속을 요하는 권한은 모두 상원에게만 있다. 그리고 하원에 대한 견제 역할(하원의 법안을 거부할 권한 등)을 담당한다. 2년의 임기로 인하여 급진적일 수밖에 없는 하원은 지나치게 급진적인 법안을 만들기 쉽다. 대표적인 예로 건강보험 개혁 당시 하원이 미국 연방 행정부에게 퍼블릭 옵션(공공건강보험기관)의 조항이 있는 반면 상원의 경우 하원안이 지나치게 세금이 많이 든다는 이유로 퍼블릭 옵션 조항을 제외하고 비영리건강보험기관이나 보험회사가 담당하도록 한 것이다. 이 경우처럼 상원은 하원이나 내각책임제가 빠지기 쉬운 국가들의 국회처럼 걸핏하면 발생하는 의회의 비정상적인 사태를 방지하는 기관이다. 상원은 급박한 처리사항의 경우가 아니면 법안을 먼저 내는 경우가 드물고 하원이 만든 법안을 수정하여 다시 하원에 되돌려보낸다. 이러한 방식으로 단원제가 빠지기 쉬운 함정을 미리 방지하는 것이다.날짜=2017-02-05'],
 'document_id': 18293,
 'id': 'mrc-1-000067',
 'original_context': '미국 상의원 또는 미국 상원(United States Senate)은 양원제인 미국 의회의 상원이다.\\n\\n미국 부통령이 상원의장이 된다. 각 주당 2명의 상원의원이 선출되어 100명의 상원의원으로 구성되어 있다. 임기는 6년이며, 2년마다 50개주 중 1/3씩 상원의원을 새로 선출하여 연방에 보낸다.\\n\\n미국 상원은 미국 하원과는 다르게 미국 대통령을 수반으로 하는 미국 연방 행정부에 각종 동의를 하는 기관이다. 하원이 세금과 경제에 대한 권한, 대통령을 포함한 대다수의 공무원을 파면할 권한을 갖고 있는 국민을 대표하는 기관인 반면 상원은 미국의 주를 대표한다. 즉 캘리포니아주, 일리노이주 같이 주 정부와 주 의회를 대표하는 기관이다. 그로 인하여 군대의 파병, 관료의 임명에 대한 동의, 외국 조약에 대한 승인 등 신속을 요하는 권한은 모두 상원에게만 있다. 그리고 하원에 대한 견제 역할(하원의 법안을 거부할 권한 등)을 담당한다. 2년의 임기로 인하여 급진적일 수밖에 없는 하원은 지나치게 급진적인 법안을 만들기 쉽다. 대표적인 예로 건강보험 개혁 당시 하원이 미국 연방 행정부에게 퍼블릭 옵션(공공건강보험기관)의 조항이 있는 반면 상원의 경우 하원안이 지나치게 세금이 많이 든다는 이유로 퍼블릭 옵션 조항을 제외하고 비영리건강보험기관이나 보험회사가 담당하도록 한 것이다. 이 경우처럼 상원은 하원이나 내각책임제가 빠지기 쉬운 국가들의 국회처럼 걸핏하면 발생하는 의회의 비정상적인 사태를 방지하는 기관이다. 상원은 급박한 처리사항의 경우가 아니면 법안을 먼저 내는 경우가 드물고 하원이 만든 법안을 수정하여 다시 하원에 되돌려보낸다. 이러한 방식으로 단원제가 빠지기 쉬운 함정을 미리 방지하는 것이다.날짜=2017-02-05',
 'question': '대통령을 포함한 미국의 행정부 견제권을 갖는 국가 기관은?',
 'retrieval_labels': [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1]}
```


