### PR TITLE
<feat> topk reader

### DIFF
--- a/prepare.py
+++ b/prepare.py
@@ -40,7 +40,6 @@ def get_retriever(args):
         - model.retriever_name : [TFIDF, DPR, BM25]
     :return: Retriever which contains embedded vector(+indexer if faiss is built).
     """
-
     retriever = RETRIEVER[args.model.retriever_name](args)
     retriever.get_embedding()
 

--- a/reader/base_reader.py
+++ b/reader/base_reader.py
@@ -15,6 +15,7 @@ class BaseReader:
 
         self.train_dataset = None
         self.eval_dataset = None
+        self.retrieved_dataset = None
 
         self.data_collator = DataCollatorWithPadding(
             self.tokenizer, pad_to_multiple_of=8 if self.args.train.fp16 else None
@@ -23,6 +24,7 @@ class BaseReader:
     def set_dataset(self, datasets, is_run=True):
         self.train_dataset = self.preprocess_dataset(self.datasets, is_train=True) if is_run else None
         self.eval_dataset = self.preprocess_dataset(datasets, is_train=False)
+        self.retrieved_dataset = datasets
 
     def preprocess_dataset(self, datasets, is_train=True):
         """
@@ -157,6 +159,7 @@ class BaseReader:
             examples=examples,
             features=features,
             predictions=predictions,
+            topk=self.args.retriever.topk,
             max_answer_length=self.args.data.max_answer_length,
             output_dir=training_args.output_dir,
             prefix="test" if self.args.train.do_predict else "valid",
@@ -167,6 +170,7 @@ class BaseReader:
             return formatted_predictions
 
         elif training_args.do_eval:
+            # query, 정답
             references = [
                 {"id": ex["id"], "answers": ex[self.answer_column_name]} for ex in self.datasets["validation"]
             ]
@@ -190,7 +194,7 @@ class DprReader(BaseReader):
             custom_args=self.args,
             train_dataset=self.train_dataset,
             eval_dataset=self.eval_dataset,
-            eval_examples=self.datasets["validation"],
+            eval_examples=self.retrieved_dataset["validation"],
             tokenizer=self.tokenizer,
             data_collator=self.data_collator,
             post_process_function=self._post_processing_function,

--- a/retrieval/base_retrieval.py
+++ b/retrieval/base_retrieval.py
@@ -35,6 +35,7 @@ class Retrieval:
         doc_scores, doc_indices = self.get_relevant_doc_bulk(query_or_dataset["question"], k=topk)
 
         for idx, example in enumerate(tqdm(query_or_dataset, desc="Retrieval: ")):
+
             for doc_id in range(topk):
                 tmp = {
                     "question": example["question"],
@@ -52,6 +53,7 @@ class Retrieval:
         if self.args.train.do_predict is True:
             f = Features(
                 {
+                    # TODO Context_id 추가
                     "context": Value(dtype="string", id=None),
                     "id": Value(dtype="string", id=None),
                     "question": Value(dtype="string", id=None),

--- a/retrieval/base_retrieval.py
+++ b/retrieval/base_retrieval.py
@@ -41,7 +41,7 @@ class Retrieval:
                     "question": example["question"],
                     "id": example["id"],
                     "context_id": doc_indices[idx][doc_id],  # retrieved id
-                    "context": self.contexts[doc_indices[idx][doc_id]],  # retrieved doument
+                    "context": self.contexts[doc_indices[idx][doc_id]],  # retrieved document
                 }
                 if "context" in example.keys() and "answers" in example.keys():
                     tmp["original_context"] = example["context"]  # original document
@@ -53,7 +53,7 @@ class Retrieval:
         if self.args.train.do_predict is True:
             f = Features(
                 {
-                    # TODO Context_id 추가
+                    "context_id" : Value(dtype="int32", id=None),
                     "context": Value(dtype="string", id=None),
                     "id": Value(dtype="string", id=None),
                     "question": Value(dtype="string", id=None),
@@ -67,6 +67,7 @@ class Retrieval:
                         length=-1,
                         id=None,
                     ),
+                    "context_id": Value(dtype="int32", id=None),
                     "context": Value(dtype="string", id=None),
                     "id": Value(dtype="string", id=None),
                     "question": Value(dtype="string", id=None),

--- a/run_mrc.py
+++ b/run_mrc.py
@@ -31,7 +31,8 @@ def train_reader(args):
         datasets = get_dataset(args, is_train=True)
         retriever = get_retriever(args)
         reader = get_reader(args, datasets)
-        
+
+        # retrieve 과정이 없어 top-k를 반환할 수 없음. 무조건 top-1만 반환
         reader.set_dataset(datasets, is_run=True)
 
         trainer = reader.get_trainer()

--- a/utils_qa.py
+++ b/utils_qa.py
@@ -32,23 +32,66 @@ def tokenize(text):
     # return text.split(" ")
     return mecab.morphs(text)
 
+def looping_through_all_features(
+        all_start_logits, all_end_logits, n_best_size, features, max_answer_length, feature_indices
+):
+    min_null_prediction = None
+    prelim_predictions = []
+    for feature_index in feature_indices:
+        start_logits = all_start_logits[feature_index]
+        end_logits = all_end_logits[feature_index]
+        offset_mapping = features[feature_index]["offset_mapping"]
+        token_is_max_context = features[feature_index].get("token_is_max_context", None)
+        feature_null_score = start_logits[0] + end_logits[0]
+        if min_null_prediction is None or min_null_prediction["score"] > feature_null_score:
+            min_null_prediction = {
+                "offsets": (0, 0),
+                "score": feature_null_score,
+                "start_logit": start_logits[0],
+                "end_logit": end_logits[0],
+            }
+        start_indexes = np.argsort(start_logits)[-1 : -n_best_size - 1 : -1].tolist()
+        end_indexes = np.argsort(end_logits)[-1 : -n_best_size - 1 : -1].tolist()
+        for start_index in start_indexes:
+            for end_index in end_indexes:
+                if (
+                    start_index >= len(offset_mapping)
+                    or end_index >= len(offset_mapping)
+                    or offset_mapping[start_index] is None
+                    or offset_mapping[end_index] is None
+                ):
+                    continue
+                if end_index < start_index or end_index - start_index + 1 > max_answer_length:
+                    continue
+                if token_is_max_context is not None and not token_is_max_context.get(str(start_index), False):
+                    continue
+                prelim_predictions.append(
+                    {
+                        "offsets": (offset_mapping[start_index][0], offset_mapping[end_index][1]),
+                        "score": start_logits[start_index] + end_logits[end_index],
+                        "start_logit": start_logits[start_index],
+                        "end_logit": end_logits[end_index],
+                    }
+                )
+    return prelim_predictions
+
 
 def postprocess_qa_predictions(
-    examples,
-    features,
-    predictions: Tuple[np.ndarray, np.ndarray],
-    version_2_with_negative: bool = False,
-    n_best_size: int = 20,
-    max_answer_length: int = 30,
-    null_score_diff_threshold: float = 0.0,
-    output_dir: Optional[str] = None,
-    prefix: Optional[str] = None,
-    is_world_process_zero: bool = True,
+        examples,
+        features,
+        predictions: Tuple[np.ndarray, np.ndarray],
+        topk: int = 3,
+        version_2_with_negative: bool = False,
+        n_best_size: int = 20,
+        max_answer_length: int = 30,
+        null_score_diff_threshold: float = 0.0,
+        output_dir: Optional[str] = None,
+        prefix: Optional[str] = None,
+        is_world_process_zero: bool = True,
 ):
     """
     Post-processes the predictions of a question-answering model to convert them to answers that are substrings of the
     original contexts. This is the base postprocessing functions for models that only return start and end logits.
-
     Args:
         examples: The non-preprocessed dataset (see the main script for more information).
         features: The processed dataset (see the main script for more information).
@@ -67,7 +110,6 @@ def postprocess_qa_predictions(
             the null answer minus this threshold, the null answer is selected for this example (note that the score of
             the null answer for an example giving several features is the minimum of the scores for the null answer on
             each feature: all features must be aligned on the fact they `want` to predict a null answer).
-
             Only useful when :obj:`version_2_with_negative` is :obj:`True`.
         output_dir (:obj:`str`, `optional`):
             If provided, the dictionaries of predictions, n_best predictions (with their scores and logits) and, if
@@ -81,157 +123,290 @@ def postprocess_qa_predictions(
     assert len(predictions) == 2, "`predictions` should be a tuple with two elements (start_logits, end_logits)."
     all_start_logits, all_end_logits = predictions
 
-    assert len(predictions[0]) == len(features), f"Got {len(predictions[0])} predictions and {len(features)} features."
+    assert len(predictions[0]) == len(
+        features), f"Got {len(predictions[0])} predictions and {len(features)} features."
 
     # Build a map example to its corresponding features.
     example_id_to_index = {k: i for i, k in enumerate(examples["id"])}
     features_per_example = collections.defaultdict(list)
     for i, feature in enumerate(features):
         features_per_example[example_id_to_index[feature["example_id"]]].append(i)
-
-    # The dictionaries we have to fill.
     all_predictions = collections.OrderedDict()
     all_nbest_json = collections.OrderedDict()
-    if version_2_with_negative:
-        scores_diff_json = collections.OrderedDict()
 
-    # Let's loop over all the examples!
+    topk_merged_predictions = []
+    # 시작
     for example_index, example in enumerate(tqdm(examples)):
-        # Those are the indices of the features associated to the current example.
         feature_indices = features_per_example[example_index]
+        # 하나의 example에 딸린 context들을 전부 돌면서 prediction 수집
+        prelim_predictions = looping_through_all_features(
+            all_start_logits, all_end_logits, n_best_size, features, max_answer_length, feature_indices
+        )  # [offset, start logit, end logit, score]
 
-        min_null_prediction = None
-        prelim_predictions = []
+        ##### V
+        if example_index % topk == 0:
+            topk_merged_predictions = []  # k개 context 묶음마다 사용하는 list
+        #####
 
-        # Looping through all the features associated to the current example.
-        for feature_index in feature_indices:
-            # We grab the predictions of the model for this feature.
-            start_logits = all_start_logits[feature_index]
-            end_logits = all_end_logits[feature_index]
-            # This is what will allow us to map some the positions in our logits to span of texts in the original
-            # context.
-            offset_mapping = features[feature_index]["offset_mapping"]
-            # Optional `token_is_max_context`, if provided we will remove answers that do not have the maximum context
-            # available in the current feature.
-            token_is_max_context = features[feature_index].get("token_is_max_context", None)
+        # TODO: document마다 score 정규화
 
-            # Update minimum null prediction.
-            feature_null_score = start_logits[0] + end_logits[0]
-            if min_null_prediction is None or min_null_prediction["score"] > feature_null_score:
-                min_null_prediction = {
-                    "offsets": (0, 0),
-                    "score": feature_null_score,
-                    "start_logit": start_logits[0],
-                    "end_logit": end_logits[0],
-                }
-
-            # Go through all possibilities for the `n_best_size` greater start and end logits.
-            start_indexes = np.argsort(start_logits)[-1 : -n_best_size - 1 : -1].tolist()
-            end_indexes = np.argsort(end_logits)[-1 : -n_best_size - 1 : -1].tolist()
-            for start_index in start_indexes:
-                for end_index in end_indexes:
-                    # Don't consider out-of-scope answers, either because the indices are out of bounds or correspond
-                    # to part of the input_ids that are not in the context.
-                    if (
-                        start_index >= len(offset_mapping)
-                        or end_index >= len(offset_mapping)
-                        or offset_mapping[start_index] is None
-                        or offset_mapping[end_index] is None
-                    ):
-                        continue
-                    # Don't consider answers with a length that is either < 0 or > max_answer_length.
-                    if end_index < start_index or end_index - start_index + 1 > max_answer_length:
-                        continue
-                    # Don't consider answer that don't have the maximum context available (if such information is
-                    # provided).
-                    if token_is_max_context is not None and not token_is_max_context.get(str(start_index), False):
-                        continue
-                    prelim_predictions.append(
-                        {
-                            "offsets": (offset_mapping[start_index][0], offset_mapping[end_index][1]),
-                            "score": start_logits[start_index] + end_logits[end_index],
-                            "start_logit": start_logits[start_index],
-                            "end_logit": end_logits[end_index],
-                        }
-                    )
-        if version_2_with_negative:
-            # Add the minimum null prediction
-            prelim_predictions.append(min_null_prediction)
-            null_score = min_null_prediction["score"]
-
-        # Only keep the best `n_best_size` predictions.
+        # 한 example에 있는 모든 predictions.
         predictions = sorted(prelim_predictions, key=lambda x: x["score"], reverse=True)[:n_best_size]
 
-        # Add back the minimum null prediction if it was removed because of its low score.
-        if version_2_with_negative and not any(p["offsets"] == (0, 0) for p in predictions):
-            predictions.append(min_null_prediction)
-
-        # Use the offsets to gather the answer text in the original context.
+        # 01 predictions 정답 텍스트 매핑
         context = example["context"]
         for pred in predictions:
             offsets = pred.pop("offsets")
-            pred["text"] = context[offsets[0] : offsets[1]]
-
-        # In the very rare edge case we have not a single non-null prediction, we create a fake prediction to avoid
-        # failure.
+            pred["text"] = context[offsets[0]: offsets[1]]
+        # 02 정답이 없다면 Fake 정답 생성
         if len(predictions) == 0 or (len(predictions) == 1 and predictions[0]["text"] == ""):
             predictions.insert(0, {"text": "empty", "start_logit": 0.0, "end_logit": 0.0, "score": 0.0})
-
-        # Compute the softmax of all scores (we do it with numpy to stay independent from torch/tf in this file, using
-        # the LogSumExp trick).
-        scores = np.array([pred.pop("score") for pred in predictions])
+        # 03 확률값 계산(sofmax)
+        scores = np.array([pred["score"] for pred in predictions])
+        #         scores = np.array([pred.pop("score") for pred in predictions])
         exp_scores = np.exp(scores - np.max(scores))
         probs = exp_scores / exp_scores.sum()
-
-        # Include the probabilities in our predictions.
         for prob, pred in zip(probs, predictions):
             pred["probability"] = prob
+            pred["ct"] = example["context"][:10]
+        # 04 제일 좋은 값 찾기 ( 여기가 Question 겹치는 곳 )
+        # "mrc-01-00001" : "하원의" , top-1
+        # "mrc-01-00001" : "하원"   , top-2 ( 덮어쓰게 된다. )
 
-        # Pick the best prediction. If the null answer is not possible, this is easy.
-        if not version_2_with_negative:
+        topk_merged_predictions.extend(predictions)
+
+        # k개 단위로 묶어서 수행할 로직
+        if (example_index + 1) % topk == 0:
+            predictions = sorted(topk_merged_predictions, key=lambda x: x["score"], reverse=True)[:n_best_size]
+
+            # 정답 로깅
             all_predictions[example["id"]] = predictions[0]["text"]
-        else:
-            # Otherwise we first need to find the best non-empty prediction.
-            i = 0
-            while predictions[i]["text"] == "":
-                i += 1
-            best_non_null_pred = predictions[i]
-
-            # Then we compare to the null prediction using the threshold.
-            score_diff = null_score - best_non_null_pred["start_logit"] - best_non_null_pred["end_logit"]
-            scores_diff_json[example["id"]] = float(score_diff)  # To be JSON-serializable.
-            if score_diff > null_score_diff_threshold:
-                all_predictions[example["id"]] = ""
-            else:
-                all_predictions[example["id"]] = best_non_null_pred["text"]
-
-        # Make `predictions` JSON-serializable by casting np.float back to float.
-        all_nbest_json[example["id"]] = [
-            {k: (float(v) if isinstance(v, (np.float16, np.float32, np.float64)) else v) for k, v in pred.items()}
-            for pred in predictions
-        ]
-
-    # If we have an output_dir, let's save all those dicts.
+            # 정답 포함 가능성 있었던 답을 로깅
+            all_nbest_json[example["id"]] = [
+                {k: (float(v) if isinstance(v, (np.float16, np.float32, np.float64)) else v) for k, v in
+                 pred.items()}
+                for pred in predictions
+            ]
+    # 그럼 이제 저장
     if output_dir is not None:
         assert os.path.isdir(output_dir), f"{output_dir} is not a directory."
-
         prediction_file = os.path.join(
             output_dir, "predictions.json" if prefix is None else f"predictions_{prefix}.json"
         )
         nbest_file = os.path.join(
             output_dir, "nbest_predictions.json" if prefix is None else f"nbest_predictions_{prefix}.json"
         )
-        if version_2_with_negative:
-            null_odds_file = os.path.join(
-                output_dir, "null_odds.json" if prefix is None else f"null_odds_{prefix}.json"
-            )
-
         with open(prediction_file, "w") as writer:
             writer.write(json.dumps(all_predictions, indent=4, ensure_ascii=False) + "\n")
         with open(nbest_file, "w") as writer:
             writer.write(json.dumps(all_nbest_json, indent=4, ensure_ascii=False) + "\n")
-        if version_2_with_negative:
-            with open(null_odds_file, "w") as writer:
-                writer.write(json.dumps(scores_diff_json, indent=4, ensure_ascii=False) + "\n")
-
     return all_predictions
+
+
+# def postprocess_qa_predictions(
+#     examples,
+#     features,
+#     predictions: Tuple[np.ndarray, np.ndarray],
+#     version_2_with_negative: bool = False,
+#     n_best_size: int = 20,
+#     max_answer_length: int = 30,
+#     null_score_diff_threshold: float = 0.0,
+#     output_dir: Optional[str] = None,
+#     prefix: Optional[str] = None,
+#     is_world_process_zero: bool = True,
+# ):
+#     """
+#     Post-processes the predictions of a question-answering model to convert them to answers that are substrings of the
+#     original contexts. This is the base postprocessing functions for models that only return start and end logits.
+#
+#     Args:
+#         examples: The non-preprocessed dataset (see the main script for more information).
+#         features: The processed dataset (see the main script for more information).
+#         predictions (:obj:`Tuple[np.ndarray, np.ndarray]`):
+#             The predictions of the model: two arrays containing the start logits and the end logits respectively. Its
+#             first dimension must match the number of elements of :obj:`features`.
+#         version_2_with_negative (:obj:`bool`, `optional`, defaults to :obj:`False`):
+#             Whether or not the underlying dataset contains examples with no answers.
+#         n_best_size (:obj:`int`, `optional`, defaults to 20):
+#             The total number of n-best predictions to generate when looking for an answer.
+#         max_answer_length (:obj:`int`, `optional`, defaults to 30):
+#             The maximum length of an answer that can be generated. This is needed because the start and end predictions
+#             are not conditioned on one another.
+#         null_score_diff_threshold (:obj:`float`, `optional`, defaults to 0):
+#             The threshold used to select the null answer: if the best answer has a score that is less than the score of
+#             the null answer minus this threshold, the null answer is selected for this example (note that the score of
+#             the null answer for an example giving several features is the minimum of the scores for the null answer on
+#             each feature: all features must be aligned on the fact they `want` to predict a null answer).
+#
+#             Only useful when :obj:`version_2_with_negative` is :obj:`True`.
+#         output_dir (:obj:`str`, `optional`):
+#             If provided, the dictionaries of predictions, n_best predictions (with their scores and logits) and, if
+#             :obj:`version_2_with_negative=True`, the dictionary of the scores differences between best and null
+#             answers, are saved in `output_dir`.
+#         prefix (:obj:`str`, `optional`):
+#             If provided, the dictionaries mentioned above are saved with `prefix` added to their names.
+#         is_world_process_zero (:obj:`bool`, `optional`, defaults to :obj:`True`):
+#             Whether this process is the main process or not (used to determine if logging/saves should be done).
+#     """
+#     assert len(predictions) == 2, "`predictions` should be a tuple with two elements (start_logits, end_logits)."
+#     all_start_logits, all_end_logits = predictions
+#
+#     assert len(predictions[0]) == len(features), f"Got {len(predictions[0])} predictions and {len(features)} features."
+#
+#
+#     # Build a map example to its corresponding features.
+#     example_id_to_index = {k: i for i, k in enumerate(examples["id"])}
+#     # 토큰 max_length로 잘라진 features(context 조각들)를 example(질문)에 연결
+#     features_per_example = collections.defaultdict(list)
+#     for i, feature in enumerate(features):
+#         features_per_example[example_id_to_index[feature["example_id"]]].append(i)
+#     # {example(질문) : features(context 조각) --> top-k context 포함}
+#
+#     # The dictionaries we have to fill.
+#     all_predictions = collections.OrderedDict()
+#     all_nbest_json = collections.OrderedDict()
+#     if version_2_with_negative:
+#         scores_diff_json = collections.OrderedDict()
+#
+#     # Let's loop over all the examples!
+#     for example_index, example in enumerate(tqdm(examples)):
+#         # Those are the indices of the features associated to the current example.
+#         feature_indices = features_per_example[example_index] # 질문에 딸린 context 모음
+#
+#         min_null_prediction = None
+#         prelim_predictions = []
+#
+#         # 각각의 context 조각(feature)마다 루프
+#         # Looping through all the features associated to the current example.
+#         for feature_index in feature_indices:
+#             # We grab the predictions of the model for this feature.
+#             start_logits = all_start_logits[feature_index]
+#             end_logits = all_end_logits[feature_index]
+#             # This is what will allow us to map some the positions in our logits to span of texts in the original
+#             # context.
+#             offset_mapping = features[feature_index]["offset_mapping"]
+#             # Optional `token_is_max_context`, if provided we will remove answers that do not have the maximum context
+#             # available in the current feature.
+#             token_is_max_context = features[feature_index].get("token_is_max_context", None)
+#
+#             # Update minimum null prediction.
+#             feature_null_score = start_logits[0] + end_logits[0]
+#             if min_null_prediction is None or min_null_prediction["score"] > feature_null_score:
+#                 min_null_prediction = {
+#                     "offsets": (0, 0),
+#                     "score": feature_null_score,
+#                     "start_logit": start_logits[0],
+#                     "end_logit": end_logits[0],
+#                 }
+#
+#             # Go through all possibilities for the `n_best_size` greater start and end logits.
+#             start_indexes = np.argsort(start_logits)[-1 : -n_best_size - 1 : -1].tolist()
+#             end_indexes = np.argsort(end_logits)[-1 : -n_best_size - 1 : -1].tolist()
+#             for start_index in start_indexes:
+#                 for end_index in end_indexes:
+#                     # Don't consider out-of-scope answers, either because the indices are out of bounds or correspond
+#                     # to part of the input_ids that are not in the context.
+#                     if (
+#                         start_index >= len(offset_mapping)
+#                         or end_index >= len(offset_mapping)
+#                         or offset_mapping[start_index] is None
+#                         or offset_mapping[end_index] is None
+#                     ):
+#                         continue
+#                     # Don't consider answers with a length that is either < 0 or > max_answer_length.
+#                     if end_index < start_index or end_index - start_index + 1 > max_answer_length:
+#                         continue
+#                     # Don't consider answer that don't have the maximum context available (if such information is
+#                     # provided).
+#                     if token_is_max_context is not None and not token_is_max_context.get(str(start_index), False):
+#                         continue
+#                     prelim_predictions.append(
+#                         {
+#                             "offsets": (offset_mapping[start_index][0], offset_mapping[end_index][1]),
+#                             "score": start_logits[start_index] + end_logits[end_index],
+#                             "start_logit": start_logits[start_index],
+#                             "end_logit": end_logits[end_index],
+#                         }
+#                     )
+#
+#         if version_2_with_negative:
+#             # Add the minimum null prediction
+#             prelim_predictions.append(min_null_prediction)
+#             null_score = min_null_prediction["score"]
+#
+#         # Only keep the best `n_best_size` predictions.
+#         predictions = sorted(prelim_predictions, key=lambda x: x["score"], reverse=True)[:n_best_size]
+#
+#         # Add back the minimum null prediction if it was removed because of its low score.
+#         if version_2_with_negative and not any(p["offsets"] == (0, 0) for p in predictions):
+#             predictions.append(min_null_prediction)
+#
+#         # Use the offsets to gather the answer text in the original context.
+#         context = example["context"]
+#         for pred in predictions:
+#             offsets = pred.pop("offsets")
+#             pred["text"] = context[offsets[0] : offsets[1]]
+#
+#         # In the very rare edge case we have not a single non-null prediction, we create a fake prediction to avoid
+#         # failure.
+#         if len(predictions) == 0 or (len(predictions) == 1 and predictions[0]["text"] == ""):
+#             predictions.insert(0, {"text": "empty", "start_logit": 0.0, "end_logit": 0.0, "score": 0.0})
+#
+#         # Compute the softmax of all scores (we do it with numpy to stay independent from torch/tf in this file, using
+#         # the LogSumExp trick).
+#         scores = np.array([pred.pop("score") for pred in predictions])
+#         exp_scores = np.exp(scores - np.max(scores))
+#         probs = exp_scores / exp_scores.sum()
+#
+#         # Include the probabilities in our predictions.
+#         for prob, pred in zip(probs, predictions):
+#             pred["probability"] = prob
+#
+#         # Pick the best prediction. If the null answer is not possible, this is easy.
+#         if not version_2_with_negative:
+#             all_predictions[example["id"]] = predictions[0]["text"]
+#         else:
+#             # Otherwise we first need to find the best non-empty prediction.
+#             i = 0
+#             while predictions[i]["text"] == "":
+#                 i += 1
+#             best_non_null_pred = predictions[i]
+#
+#             # Then we compare to the null prediction using the threshold.
+#             score_diff = null_score - best_non_null_pred["start_logit"] - best_non_null_pred["end_logit"]
+#             scores_diff_json[example["id"]] = float(score_diff)  # To be JSON-serializable.
+#             if score_diff > null_score_diff_threshold:
+#                 all_predictions[example["id"]] = ""
+#             else:
+#                 all_predictions[example["id"]] = best_non_null_pred["text"]
+#
+#         # Make `predictions` JSON-serializable by casting np.float back to float.
+#         all_nbest_json[example["id"]] = [
+#             {k: (float(v) if isinstance(v, (np.float16, np.float32, np.float64)) else v) for k, v in pred.items()}
+#             for pred in predictions
+#         ]
+#
+#     # If we have an output_dir, let's save all those dicts.
+#     if output_dir is not None:
+#         assert os.path.isdir(output_dir), f"{output_dir} is not a directory."
+#
+#         prediction_file = os.path.join(
+#             output_dir, "predictions.json" if prefix is None else f"predictions_{prefix}.json"
+#         )
+#         nbest_file = os.path.join(
+#             output_dir, "nbest_predictions.json" if prefix is None else f"nbest_predictions_{prefix}.json"
+#         )
+#         if version_2_with_negative:
+#             null_odds_file = os.path.join(
+#                 output_dir, "null_odds.json" if prefix is None else f"null_odds_{prefix}.json"
+#             )
+#
+#         with open(prediction_file, "w") as writer:
+#             writer.write(json.dumps(all_predictions, indent=4, ensure_ascii=False) + "\n")
+#         with open(nbest_file, "w") as writer:
+#             writer.write(json.dumps(all_nbest_json, indent=4, ensure_ascii=False) + "\n")
+#         if version_2_with_negative:
+#             with open(null_odds_file, "w") as writer:
+#                 writer.write(json.dumps(scores_diff_json, indent=4, ensure_ascii=False) + "\n")
+#
+#     return all_predictions

--- a/utils_qa.py
+++ b/utils_qa.py
@@ -38,7 +38,6 @@ def looping_through_all_features(
     min_null_prediction = None
     prelim_predictions = []
     for feature_index in feature_indices:
-        print(f'{feature_index}', end=" ")
         start_logits = all_start_logits[feature_index]
         end_logits = all_end_logits[feature_index]
         offset_mapping = features[feature_index]["offset_mapping"]
@@ -74,7 +73,6 @@ def looping_through_all_features(
                         "end_logit": end_logits[end_index],
                     }
                 )
-    print("")
     return prelim_predictions
 
 
@@ -129,28 +127,23 @@ def postprocess_qa_predictions(
         features), f"Got {len(predictions[0])} predictions and {len(features)} features."
 
     # Build a map example to its corresponding features.
-    # example_id_to_index가 애초에 topk개 단위로 잘려서 들어간다. k: i 이므로 동일한 key를 가진 것이 topk개 들어오면 마지막 1개로 덮어씌워짐.
-    # example_id_to_index {'mrc-0-00XXXX' : 2, 'mrc-0-00CCCC' : 5, ...}
-    example_id_to_index = {k: i for i, k in enumerate(examples["id"])}
+    # example_id_to_index = {'mrc-0-00XXXX' : 0, 'mrc-0-00CCCC' : 1, ....} --> topk개를 묶어서 index 하나로 처리.
+    example_id_to_index = {k: i//topk for i, k in enumerate(examples["id"])}
+
     features_per_example = collections.defaultdict(list)
-    # feature['example_id'] ==> answers, example_id, original context 등 들고 있는 retrieved doc
-    # example_id_to_index[feature['example_id']] ==> 'mrc-0-00XXX' 같은 QA id를 key로 넣어서, index값 (2,5,8...)을 반환받고 해당 index로 연결시킴.
+    # ex) features_per_example[0] ==> [0,1,2,3,4,5,6]
     for i, feature in enumerate(features):
-        features_per_example[example_id_to_index[feature["example_id"]]].append(i)
+        features_per_example[example_id_to_index[feature['example_id']]].append(i)
     all_predictions = collections.OrderedDict()
     all_nbest_json = collections.OrderedDict()
 
-    # for i in range(6):
-    #     print(examples[i])
-    #     print('\n\n')
-
-
     topk_merged_predictions = []
+
     # 시작
     for example_index, example in enumerate(tqdm(examples)):
         feature_indices = features_per_example[example_index]
 
-        print(f"example {example_index} | feature_indices {feature_indices}")
+        # print(f"example {example_index} | feature_indices {feature_indices}")
 
         # 하나의 example에 딸린 context들을 전부 돌면서 prediction 수집
         prelim_predictions = looping_through_all_features(
@@ -163,7 +156,6 @@ def postprocess_qa_predictions(
         #####
 
         # TODO: document마다 score 정규화
-
 
         # 한 example에 있는 모든 predictions.
         predictions = sorted(prelim_predictions, key=lambda x: x["score"], reverse=True)[:n_best_size]
@@ -184,29 +176,25 @@ def postprocess_qa_predictions(
         for prob, pred in zip(probs, predictions):
             pred["probability"] = prob
             pred["answer"] = example['answers']['text']
-            pred["context"] = example['context'][:10]
-            pred["original_context"] = example['original_context']
+            pred["context_id"] = example['context_id']
+            pred["context"] = example['context']
         # 04 제일 좋은 값 찾기 ( 여기가 Question 겹치는 곳 )
         # "mrc-01-00001" : "하원의" , top-1
         # "mrc-01-00001" : "하원"   , top-2 ( 덮어쓰게 된다. )
 
-        # 빈 답을 거름
-        if predictions[0]["score"] != 0.0:
-            topk_merged_predictions.extend(predictions)
+        topk_merged_predictions.extend(predictions)
 
-        print(
-            f"len(predictions): {len(predictions)} | len(topk_merged_predictions) : {len(topk_merged_predictions)} | len(prelimed) : {len(prelim_predictions)}")
+        # print(
+        #     f"len(predictions): {len(predictions)} | len(topk_merged_predictions) : {len(topk_merged_predictions)} | len(prelimed) : {len(prelim_predictions)}")
 
         # k개 단위로 묶어서 수행할 로직
         if (example_index + 1) % topk == 0:
 
-            # 1. 그냥 softmax한걸로 score 계산해보기
+            # (빈 답 거르고 softmax한 probability로 계산?)
+            # topk_merged_predictions = [pred for pred in topk_merged_predictions if pred["probability"] != 1.0]
 
-            predictions = topk_merged_predictions
-            # topk_merged_predictions = [pred for pred in topk_merged_predictions if pred["text"] != ""]
-            # predictions = sorted(topk_merged_predictions, key=lambda x: x["probability"], reverse=True)[:n_best_size]
-
-
+            # 1. score로 계산
+            predictions = sorted(topk_merged_predictions, key=lambda x: x["score"], reverse=True)[:n_best_size]
 
             # 정답 로깅
             all_predictions[example["id"]] = predictions[0]["text"]


### PR DESCRIPTION
post_process_qa_prediction 파트 수정하여 topk reading 기능 추가했습니다.

<img width="324" alt="Screen Shot 2021-05-08 at 9 29 21 PM" src="https://user-images.githubusercontent.com/26772420/117539179-74df7b80-b044-11eb-8122-380250c3eb60.png">
<img width="316" alt="Screen Shot 2021-05-08 at 9 29 56 PM" src="https://user-images.githubusercontent.com/26772420/117539193-8aed3c00-b044-11eb-86c2-5a0762f4ade0.png">

위 그림에서 topk가 기존의 k=1인 상태, top-5가 k=5인 상태입니다.  EM 5%, f1 4% 가량 상승했습니다.

코드가 좀 더럽게 짜여있고 주석이 많이 달려있는데, 나중에 지울 예정이긴 하지만 마음에 걸리시면 지금 지우셔도 됩니다(...)
딕셔너리나 데이터셋 사용이 조금 복잡한 부분이 많아서 혹시 리팩토링하실때 도움이 될까봐 남겨놓았습니다.

이렇게 오래 걸릴일은 아니었는데 코드가 너무 길고 복잡해서 디버깅하느라 시간을 다 날렸네요 ㅠㅠ
점심즘부터 계속 하고있었는데 건모님 오시자마자 정리됐습니다. 갓건모!
어제 리팩토링도 대부분 해주셨는데 정말 감사합니다!