### PR TITLE
<hotfix> Remove experimental variables

### DIFF
--- a/retrieval/base_retrieval.py
+++ b/retrieval/base_retrieval.py
@@ -35,8 +35,8 @@ class Retrieval:
         assert self.p_embedding is not None, "get_embedding()을 먼저 수행한 후에 retrieve()를 작동시켜 주세요. "
 
         total = []
-        # 중복을 걸러내기 위해 40 + topk (확인된 최대 중복 개수 40 + topk개)으로 최소값을 설정하고, topk의 3배수로 뽑습니다.
-        alpha = 3
+        # 중복을 걸러내기 위해 40 + topk (확인된 최대 중복 개수 40 + topk개)으로 최소값을 설정하고, topk의 alpha 배수로 뽑습니다.
+        alpha = 2
         doc_scores, doc_indices = self.get_relevant_doc_bulk(query_or_dataset["question"], topk=max(40+topk,alpha*topk))
 
         for idx, example in enumerate(tqdm(query_or_dataset, desc="Retrieval: ")):

--- a/retrieval/sparse/bm25.py
+++ b/retrieval/sparse/bm25.py
@@ -27,7 +27,7 @@ class BM25Retrieval(SparseRetrieval):
 
         self.b = self.args.retriever.b
         self.k1 = self.args.retriever.k1
-        self.encoder = TfidfVectorizer(tokenizer=self.tokenizer, ngram_range=(1, 2), norm=None, smooth_idf=False)
+        self.encoder = TfidfVectorizer(tokenizer=self.tokenizer, ngram_range=(1, 2))
 
         self.avdl = None
         self.p_embedding = None


### PR DESCRIPTION
실험하느라 넣어두었던 변수들 때문에 accuracy 낮게 나오는 문제 수정했습니다.
3배수로 설정해 두었더니 retrieval 시간이 오래걸려서 2배수로 낮췄습니다. 늘리고 싶으시면 base_retrieval의 alpha 조정해 주시면 됩니다.