### PR TITLE
<feat> Add ATIRE BM25

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ ST00.json 하이퍼파라미터는 아래 파일들을 참고해서 수정할 �
     "data": {
         "dataset_name": "train_dataset",
         "sub_datasets": "kor_dataset",
-        "sub_datasets_ratio": "0.4"
+        "sub_datasets_ratio": "0.4",
         "overwrite_cache": false,
         "preprocessing_num_workers": 2,
         "max_seq_length": 384,

--- a/prepare.py
+++ b/prepare.py
@@ -6,13 +6,14 @@ from transformers import AutoConfig, AutoModelForQuestionAnswering, AutoTokenize
 
 from reader import DprReader
 from retrieval.hybrid import Bm25DprBert, TfidfDprBert
-from retrieval.sparse import TfidfRetrieval, BM25Retrieval
+from retrieval.sparse import TfidfRetrieval, BM25Retrieval, BM25ATTIRERetrieval
 from retrieval.dense import DprBert, BaseTrainMixin, Bm25TrainMixin
 
 
 RETRIEVER = {
     # Sparse
     "BM25": BM25Retrieval,
+    "BM25ATTIRE": BM25ATTIRERetrieval,
     "TFIDF": TfidfRetrieval,
     # Dense
     "DPRBERT": DprBert,

--- a/prepare.py
+++ b/prepare.py
@@ -6,14 +6,14 @@ from transformers import AutoConfig, AutoModelForQuestionAnswering, AutoTokenize
 
 from reader import DprReader
 from retrieval.hybrid import Bm25DprBert, TfidfDprBert
-from retrieval.sparse import TfidfRetrieval, BM25Retrieval, BM25ATTIRERetrieval
+from retrieval.sparse import TfidfRetrieval, BM25Retrieval, ATIREBM25Retrieval
 from retrieval.dense import DprBert, BaseTrainMixin, Bm25TrainMixin
 
 
 RETRIEVER = {
     # Sparse
     "BM25": BM25Retrieval,
-    "BM25ATTIRE": BM25ATTIRERetrieval,
+    "ATIREBM25": ATIREBM25Retrieval,
     "TFIDF": TfidfRetrieval,
     # Dense
     "DPRBERT": DprBert,

--- a/retrieval/sparse/__init__.py
+++ b/retrieval/sparse/__init__.py
@@ -1,4 +1,4 @@
 from retrieval.sparse.sparse_base import SparseRetrieval
 from retrieval.sparse.tfidf import TfidfRetrieval
 from retrieval.sparse.bm25 import BM25Retrieval
-from retrieval.sparse.bm25_attire import BM25ATTIRERetrieval
+from retrieval.sparse.atire_bm25 import ATIREBM25Retrieval

--- a/retrieval/sparse/__init__.py
+++ b/retrieval/sparse/__init__.py
@@ -1,3 +1,4 @@
 from retrieval.sparse.sparse_base import SparseRetrieval
 from retrieval.sparse.tfidf import TfidfRetrieval
 from retrieval.sparse.bm25 import BM25Retrieval
+from retrieval.sparse.bm25_attire import BM25ATTIRERetrieval

--- a/retrieval/sparse/atire_bm25.py
+++ b/retrieval/sparse/atire_bm25.py
@@ -10,7 +10,7 @@ from transformers import AutoTokenizer
 from retrieval.sparse import SparseRetrieval
 
 
-class BM25ATTIRERetrieval(SparseRetrieval):
+class ATIREBM25Retrieval(SparseRetrieval):
     def __init__(self, args):
         super().__init__(args)
 

--- a/retrieval/sparse/bm25_attire.py
+++ b/retrieval/sparse/bm25_attire.py
@@ -1,4 +1,4 @@
-import tqdm
+from tqdm.auto import tqdm
 import pickle
 import numpy as np
 import os.path as p
@@ -10,9 +10,14 @@ from transformers import AutoTokenizer
 from retrieval.sparse import SparseRetrieval
 
 
-class BM25Retrieval(SparseRetrieval):
+class BM25ATTIRERetrieval(SparseRetrieval):
     def __init__(self, args):
         super().__init__(args)
+
+        save_dir = p.join(args.path.embed, self.name)
+        self.encoder_path = p.join(save_dir, f"{self.name}.bin")
+        self.idf_encoder_path = p.join(save_dir, f"{self.name}_idf.bin")
+        self.idf_path = p.join(save_dir, "idf.bin")
 
         if self.args.model.tokenizer_name == "":
             print("Using Mecab tokenizer")
@@ -27,24 +32,32 @@ class BM25Retrieval(SparseRetrieval):
 
         self.b = self.args.retriever.b
         self.k1 = self.args.retriever.k1
-        self.encoder = TfidfVectorizer(tokenizer=self.tokenizer, ngram_range=(1, 2))
+        self.encoder = TfidfVectorizer(tokenizer=self.tokenizer, ngram_range=(1, 2), use_idf=False, norm=None)
+        self.idf_encoder = TfidfVectorizer(tokenizer=self.tokenizer, ngram_range=(1, 2), norm=None, smooth_idf=False)
         self.dls = np.zeros(len(self.contexts))
 
         for idx, context in enumerate(self.contexts):
             self.dls[idx] = len(context)
 
-        self.avdl = sum(self.dls)/len(self.contexts)
+        self.avdl = np.mean(self.dls)
         self.p_embedding = None
+        self.idf = None
 
     def get_embedding(self):
-        if p.isfile(self.embed_path) and p.isfile(self.encoder_path) and not self.args.retriever.retrain:
+        if p.isfile(self.embed_path) and p.isfile(self.encoder_path) and p.isfile(self.idf_encoder_path) and p.isfile(self.idf_path) and not self.args.retriever.retrain:
             with open(self.embed_path, "rb") as f:
                 self.p_embedding = pickle.load(f)
 
             with open(self.encoder_path, "rb") as f:
                 self.encoder = pickle.load(f)
+
+            with open(self.idf_encoder_path, "rb") as f:
+                self.idf_encoder = pickle.load(f)
+
+            with open(self.idf_path, "rb") as f:
+                self.idf = pickle.load(f)
         else:
-            self.p_embedding, self.encoder = self._exec_embedding()
+            self.p_embedding, self.encoder, self.idf, self.idf_encoder = self._exec_embedding()
 
             with open(self.embed_path, "wb") as f:
                 pickle.dump(self.p_embedding, f)
@@ -52,31 +65,38 @@ class BM25Retrieval(SparseRetrieval):
             with open(self.encoder_path, "wb") as f:
                 pickle.dump(self.encoder, f)
 
-        self.avdl = self.p_embedding.sum(1).mean()
+            with open(self.idf_path, "wb") as f:
+                pickle.dump(self.idf, f)
+
+            with open(self.idf_encoder_path, "wb") as f:
+                pickle.dump(self.idf_encoder, f)
 
     def _exec_embedding(self):
-        self.encoder.fit(self.contexts)
-        self.p_embedding = self.encoder.transform(self.contexts)
-        return self.p_embedding, self.encoder
+        self.p_embedding = self.encoder.fit_transform(tqdm(self.contexts, desc="TF calculation: "))
+        self.idf_encoder.fit(tqdm(self.contexts, desc="IDF calculation: "))
+        self.idf = self.idf_encoder.idf_
+
+        return self.p_embedding, self.encoder, self.idf, self.idf_encoder
 
     def get_relevant_doc_bulk(self, queries, topk):
         query_vecs = self.encoder.transform(queries)
 
         b, k1, avdl = self.b, self.k1, self.avdl
-        len_p = self.p_embedding.sum(1).A1
+        len_p = self.dls
 
         doc_scores = []
         doc_indices = []
 
         p_embedding = self.p_embedding.tocsc()
 
-        for query_vec in tqdm.tqdm(query_vecs):
+        for query_vec in tqdm(query_vecs):
             p_emb_for_q = p_embedding[:, query_vec.indices]
             denom = p_emb_for_q + (k1 * (1 - b + b * len_p / avdl))[:, None]
 
             # idf(t) = log [ n / df(t) ] + 1 in sklearn, so it need to be converted
             # to idf(t) = log [ n / df(t) ] with minus 1
-            idf = self.encoder._tfidf.idf_[None, query_vec.indices] - 1.0
+            idf = self.idf[None, query_vec.indices] - 1.0
+
             numer = p_emb_for_q.multiply(np.broadcast_to(idf, p_emb_for_q.shape)) * (k1 + 1)
 
             result = (numer / denom).sum(1).A1
@@ -88,4 +108,5 @@ class BM25Retrieval(SparseRetrieval):
             doc_score, doc_indice = result[sorted_result_idx].tolist()[:topk], sorted_result_idx.tolist()[:topk]
             doc_scores.append(doc_score)
             doc_indices.append(doc_indice)
+
         return doc_scores, doc_indices


### PR DESCRIPTION
기존 BM25 코드가 SKlearn TFIDF vectorizer를 활용하는 과정에서 구현이 제대로 되지 않았던 오류가 있어서,
`term frequency`와 `IDF`를 각각 따로 계산하고, `document length`와 `average document length`를 제대로 넣어주는 방식으로 다시 구현한 후 논문에 나온 `b=0.3`, `k1=1.1` 값을 사용했습니다. 일반적으로 사용된다고 알려진 `b=0.75`, `k=1.2`보다 높은 성능을 보입니다. 

전략 예시는 다음과 같습니다.

```json
{
    "alias": "ATIRE_BM25",
    "model": {
        "model_name_or_path": "monologg/koelectra-small-v3-discriminator",
        "config_name": "",
        "tokenizer_name": "xlm-roberta-large",
        "retriever_name": "ATIREBM25"
    },
    "data": {
        "dataset_name": "train_dataset",
        "overwrite_cache": false,
        "cache_file_name" : "cache-train.arrow",
        "preprocessing_num_workers": 4,
        "max_seq_length": 384,
        "pad_to_max_length": false,
        "doc_stride": 128,
        "max_answer_length": 30,
        "train_retrieval": true,
        "eval_retrieval": true
    },
    "train": {
        "do_train": true,
        "do_eval": true,
        "save_total_limit": 2,
        "save_steps": 100,
        "logging_steps": 100,
        "overwrite_output_dir": true,
        "report_to": ["wandb"]
    },
    "retriever": {
        "retrain": true,
        "dense_train_dataset": "train_dataset",
        "topk": 10,
        "b": 0.3,
        "k1": 1.1
    }
}
```