### PR TITLE
<refactor> ensemble용으로 utils_qa 리팩토링

### DIFF
--- a/config/readme.md
+++ b/config/readme.md
@@ -28,7 +28,7 @@
 - do_train: bool = False,
 - do_eval: bool = None,
 - do_predict: bool = False,
-- evaluation_strategy: transformers.trainer_utils.IntervalStrategy = 'no'
+- evaluation_strategy: transformers.trainer_utils.IntervalStrategy = 'no',
 - prediction_loss_only: bool = False,
 - per_device_train_batch_size: int = 8,
 - per_device_eval_batch_size: int = 8,
@@ -87,5 +87,5 @@
 - dataloader_pin_memory: bool = True,
 - skip_memory_metrics: bool = False,
 - mp_parameters: str = '',
-- **_(custom) pororo_prediction: bool = False_**
+- **_(custom) pororo_prediction: bool = False,_**
 - **_(custom) do_ensemble: bool = False_**

--- a/config/readme.md
+++ b/config/readme.md
@@ -28,7 +28,7 @@
 - do_train: bool = False,
 - do_eval: bool = None,
 - do_predict: bool = False,
-- evaluation_strategy: transformers.trainer_utils.IntervalStrategy = 'no',
+- evaluation_strategy: transformers.trainer_utils.IntervalStrategy = 'no'
 - prediction_loss_only: bool = False,
 - per_device_train_batch_size: int = 8,
 - per_device_eval_batch_size: int = 8,
@@ -88,3 +88,4 @@
 - skip_memory_metrics: bool = False,
 - mp_parameters: str = '',
 - **_(custom) pororo_prediction: bool = False_**
+- **_(custom) do_ensemble: bool = False_**

--- a/config/train_args.py
+++ b/config/train_args.py
@@ -10,4 +10,5 @@ class TrainArguments:
 
     output_dir: Optional[str] = field(default="train_checkpoint", metadata={"help": "checkpoint_dir"})
     pororo_prediction: Optional[bool] = field(default=False, metadata={"help": "pororo mrc model voting(ensemble)"})
+    do_ensemble: Optional[bool] = field(default=False, metadata={"help": "use ensemble.py for prediction"})
     # TrainArguments는 config/ST00.json 에서 수정해 주시면 됩니다.

--- a/predict.py
+++ b/predict.py
@@ -13,7 +13,7 @@ def predict(args):
         args = update_args(args, strategy)  # auto add args.save_path, args.base_path
         args.strategy = strategy
 
-        # args.model.model_name_or_path = args.model_path
+        args.model.model_name_or_path = args.model_path
         args.train.output_dir = p.join(args.path.checkpoint, strategy)
         args.train.do_predict = True
 

--- a/predict.py
+++ b/predict.py
@@ -13,7 +13,7 @@ def predict(args):
         args = update_args(args, strategy)  # auto add args.save_path, args.base_path
         args.strategy = strategy
 
-        args.model.model_name_or_path = args.model_path
+        # args.model.model_name_or_path = args.model_path
         args.train.output_dir = p.join(args.path.checkpoint, strategy)
         args.train.do_predict = True
 

--- a/reader/base_reader.py
+++ b/reader/base_reader.py
@@ -154,15 +154,21 @@ class BaseReader:
         return tokenized_examples
 
     def _post_processing_function(self, examples, features, predictions, training_args):
-        predictions, pororo_predictions = postprocess_qa_predictions(
+        predictions = postprocess_qa_predictions(
             examples=examples,
             features=features,
             predictions=predictions,
+            training_args=training_args,
             topk=self.args.retriever.topk,
             max_answer_length=self.args.data.max_answer_length,
             output_dir=training_args.output_dir,
             prefix="test" if self.args.train.do_predict else "valid",
         )
+        if training_args.pororo_prediction:
+            predictions, pororo_predictions = predictions
+        else:
+            predictions = predictions[0]
+
 
         formatted_predictions = [{"id": k, "prediction_text": v} for k, v in predictions.items()]
         if training_args.pororo_prediction:

--- a/tools.py
+++ b/tools.py
@@ -138,6 +138,8 @@ def get_args():
     parser = HfArgumentParser((ModelArguments, DataTrainingArguments, TrainArguments, RetrievalTrainingArguments))
     model_args, data_args, train_args, retriever_args = parser.parse_args_into_dataclasses(args=[])
 
+    # train_args : TrainingArgument Datasetdict인데, pororo_prediction key가 없어서 update_args에서 오류가 뜰 수 있어 key값 미리 initialize
+    # training_args : pororo_prediction와 output_dir를 추가반영하여 만든 custom argument(config의 train argument에 가까운)
     training_args = TrainingArguments(output_dir=args.path.checkpoint)
     training_args.pororo_prediction = train_args.pororo_prediction
 

--- a/utils_qa.py
+++ b/utils_qa.py
@@ -385,27 +385,6 @@ def pororo_ensemble(examples, output_dir, prefix, topk):
 
 
 
-'''
-postprocess_qa_predictions
-- function 1
-    여기서 return하도록.
-        - logits : 3중리스트. [ <-- 모델의 600개 prediction을 묶는
-                                [ <-- 하나의 question을 묶는  
-                                    [(s1, e1), (s2, e2), ...] <-- 하나의 context을 묶는)
-                                ] 
-                            ]
-        - offsets : 마찬가지
-        - contexts : 그냥 context 넘겨주세
-- function 2 
-- function 3 (prediction.json 생성)
-
-
-- prelimed predictions(->logits), example의 document_id, context, question id(mrc-xxx)값 넘겨주기. 리스트형태로.
-
-- 뽀로로 training args 받아서 사용 하고 말고 결 
-'''
-
-
 
 def postprocess_qa_predictions(
         examples,

--- a/utils_qa.py
+++ b/utils_qa.py
@@ -290,8 +290,10 @@ def load_predictions_from_json(data_dir, prefix):
     nbest_file = os.path.join(
         data_dir, "nbest_predictions.json" if prefix is None else f"nbest_predictions_{prefix}.json"
     )
+
     with open(prediction_file, "r") as prediction_file:
         predictions = json.load(prediction_file)
+
     with open(nbest_file, "r") as nbest_file:
         nbests = json.load(nbest_file)
 
@@ -364,9 +366,9 @@ def pororo_ensemble(examples, output_dir, prefix, topk):
 
     # MRC 모델로 예측하기
     all_pororo_preds = pororo_predict(examples, pororo_mrc, topk)
-    return all_pororo_preds
     # MRC 모델 예측 결과를 기존 결과에 합치기
-    all_pororo_voted_predictions, all_pororo_voted_nbest_json = pororo_voting(all_pororo_preds, output_dir, prefix, topk)
+    all_pororo_voted_predictions, all_pororo_voted_nbest_json = pororo_voting(examples, all_pororo_preds, output_dir,
+                                                                              prefix, topk)
 
     # 저장하기
     pororo_voted_prediction_file = os.path.join(
@@ -450,7 +452,7 @@ def postprocess_qa_predictions(
     if output_dir is not None:
         save_predictions_to_json(final_predictions, all_nbest_json, output_dir, prefix)
         if training_args.pororo_prediction:
-            all_pororo_voted_predictions = pororo_ensemble()
+            all_pororo_voted_predictions = pororo_ensemble(examples, output_dir, prefix, topk)
             return (final_predictions, all_pororo_voted_predictions)
 
     return (final_predictions)


### PR DESCRIPTION
utils_qa 내부의 결합력 강하던 post_process 함수를  기능 단위로 쪼개고, 중간에 ensemble용으로 값을 반환하는 로직도 추가했습니다.
ensemble을 위해서는 argument의 train에서 `do_ensemble`을 true로 켜주어야하는데, 현재 ensemble파트가 아직 미구현되어 **true로 켜놓으시면 predict나 run이 제대로 되지 않습니다.** 따라서 ensemble.py가 구현되었을때만, 제출용 파일 생성 목적으로 사용해주세요.

또, 기존에는 pororo_prediction 옵션을 꺼놓아도 실제로는 사용하고 있었는데, 리팩토링하여 pororo_prediction이 false면 후처리시 pororo를 완전히 사용하지 않도록 바꾸었습니다.

utils_qa 코드의 기능별 함수에도 docstring을 추가했는데, 아직 추가하지 않은 함수들이 몇몇 있습니다. 나중에 추가하겠습니다!