### PR TITLE
<feat> head 추가, README argument 추가, exact match embedding 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,7 @@ ST00.json 하이퍼파라미터는 아래 파일들을 참고해서 수정할 �
         "save_steps": 100,
         "logging_steps": 100,
         "overwrite_output_dir": true,
+        "freeze_backbone": false,
         "report_to": ["wandb"]
     },
     "retriever": {

--- a/predict.py
+++ b/predict.py
@@ -13,7 +13,7 @@ def predict(args):
         args = update_args(args, strategy)  # auto add args.save_path, args.base_path
         args.strategy = strategy
 
-        args.model.model_name_or_path = args.model_path
+        # args.model.model_name_or_path = args.model_path
         args.train.output_dir = p.join(args.path.checkpoint, strategy)
         args.train.do_predict = True
 

--- a/prepare.py
+++ b/prepare.py
@@ -35,6 +35,7 @@ READER = {
     "CNN": CustomHeadReader,
     "LSTM": CustomHeadReader,
     "CCNN": CustomHeadReader,
+    "CCNN_v2": CustomHeadReader,
     "CNN_LSTM": CustomHeadReader,
     "CCNN_EM": CustomHeadReader,
     "NEW_CNN": CustomHeadReader

--- a/prepare.py
+++ b/prepare.py
@@ -36,7 +36,8 @@ READER = {
     "LSTM": CustomHeadReader,
     "CCNN": CustomHeadReader,
     "CNN_LSTM": CustomHeadReader,
-    "CCNN_EM": CustomHeadReader
+    "CCNN_EM": CustomHeadReader,
+    "NEW_CNN": CustomHeadReader
 }
 
 def retriever_mixin_factory(name, base, mixin):
@@ -141,6 +142,8 @@ def get_dataset(args, is_train=True):
             datasets = load_from_disk(p.join(args.path.train_data_dir, args.data.dataset_name))
         else:
             datasets = load_from_disk(p.join(args.path.train_data_dir, "test_dataset"))
+    elif args.data.dataset_name == "train_sent_dataset" or args.data.dataset_name == "shuffled_dataset":
+        datasets = load_from_disk(p.join(args.path.train_data_dir, args.data.dataset_name))
     elif args.data.dataset_name == "squad_kor_v1":
         datasets = load_dataset(args.data.dataset_name)
     # Add more dataset option here.

--- a/prepare.py
+++ b/prepare.py
@@ -25,11 +25,15 @@ RETRIEVER = {
     "LOG_ATIREBM25_DPRBERT": LogisticAtireBm25DprBert,
 }
 
-READER = {"DPR": DprReader, 
-          "FC": CustomHeadReader, 
-          "CNN": CustomHeadReader, 
-          "LSTM": CustomHeadReader,
-          "CCNN": CustomHeadReader}
+READER = {
+    "DPR": DprReader,
+    "FC": CustomHeadReader,
+    "CNN": CustomHeadReader,
+    "LSTM": CustomHeadReader,
+    "CCNN": CustomHeadReader,
+    "CNN_LSTM": CustomHeadReader,
+    "CCNN_EM": CustomHeadReader
+}
 
 def retriever_mixin_factory(name, base, mixin):
     """ mixin class의 method를 overwriting."""

--- a/reader/custom_head.py
+++ b/reader/custom_head.py
@@ -83,11 +83,34 @@ class CnnLstmQAHead(nn.Module):
         """
         x, exact_match_pos = inputs
         
-        x = x + self.em_embedding(x) # (8, 384(문장길이), 768(임베딩)) => x[2] + em_embedding[2] / x[8] + em_embedding[8]
+        x = x + self.em_embedding(exact_match_pos) # (8, 384(문장길이), 768(임베딩)) => x[2] + em_embedding[2] / x[8] + em_embedding[8]
         x, (_, _) = self.lstm(x) 
+
+        x = x.transpose(1, 2).contiguous()
         conv1_out = self.conv_1(x).transpose(1, 2).contiguous().squeeze(-1)
         conv3_out = self.conv_3(x).transpose(1, 2).contiguous().squeeze(-1)
         conv5_out = self.conv_5(x).transpose(1, 2).contiguous().squeeze(-1)
-        x = self.pooler(x)
+        x = self.fc(torch.cat((conv1_out, conv3_out, conv5_out), -1))
 
         return x
+
+class ComplexCnnEmQAHead(nn.Module):
+    def __init__(self, input_size):
+        super().__init__()
+        self.em_embedding = nn.Embedding(num_embeddings=384, embedding_dim=768)
+        self.conv_1 = nn.Conv1d(in_channels=input_size, out_channels=256, kernel_size=1, padding=0)
+        self.conv_3 = nn.Conv1d(in_channels=input_size, out_channels=256, kernel_size=3, padding=1)
+        self.conv_5 = nn.Conv1d(in_channels=input_size, out_channels=256, kernel_size=5, padding=2)
+        self.fc = nn.Linear(768, 2)
+
+    def forward(self, inputs):
+        x, exact_match_pos = inputs
+        x = x + self.em_embedding(exact_match_pos) # (8, 384(문장길이), 768(임베딩)) => x[2] + em_embedding[2] / x[8] + em_embedding[8]
+
+        x = x.transpose(1, 2).contiguous()
+        conv1_out = self.conv_1(x).transpose(1, 2).contiguous().squeeze(-1)
+        conv3_out = self.conv_3(x).transpose(1, 2).contiguous().squeeze(-1)
+        conv5_out = self.conv_5(x).transpose(1, 2).contiguous().squeeze(-1)
+        output = self.fc(torch.cat((conv1_out, conv3_out, conv5_out), -1))
+
+        return output

--- a/reader/custom_head.py
+++ b/reader/custom_head.py
@@ -10,7 +10,7 @@ class LstmQAHead(nn.Module):
     def __init__(self, input_size):
         super().__init__()
         self.lstm = nn.LSTM(input_size=input_size, hidden_size=input_size, num_layers=3, dropout=0.3, bidirectional=True, batch_first=True)
-        self.pooler = nn.Linear(1536, 2) # nn.AdaptiveAvgPool1d(-1)
+        self.pooler = nn.Linear(input_size * 2, 2) # nn.AdaptiveAvgPool1d(-1)
 
     def forward(self, x):
         x, (_, _) = self.lstm(x) 
@@ -63,3 +63,31 @@ class ComplexCnnQAHead(nn.Module):
         output = self.fc(torch.cat((conv1_out, conv3_out, conv5_out), -1))
 
         return output
+
+
+class CnnLstmQAHead(nn.Module):
+    def __init__(self, input_size):
+        super().__init__()
+        self.em_embedding = nn.Embedding(num_embeddings=384, embedding_dim=768)
+        self.lstm = nn.LSTM(input_size=input_size, hidden_size=input_size, num_layers=3, dropout=0.5, bidirectional=True, batch_first=True)
+        self.conv_1 = nn.Conv1d(in_channels=input_size * 2, out_channels=256, kernel_size=1, padding=0)
+        self.conv_3 = nn.Conv1d(in_channels=input_size * 2, out_channels=256, kernel_size=3, padding=1)
+        self.conv_5 = nn.Conv1d(in_channels=input_size * 2, out_channels=256, kernel_size=5, padding=2)
+        self.fc = nn.Linear(768, 2)
+
+    def forward(self, inputs):
+        """
+            x (8, 384)
+            exact_match_pos (8, 384)
+                = [[0, 1, 0, 0, ..., 1, 0, ...], ...]
+        """
+        x, exact_match_pos = inputs
+        
+        x = x + self.em_embedding(x) # (8, 384(문장길이), 768(임베딩)) => x[2] + em_embedding[2] / x[8] + em_embedding[8]
+        x, (_, _) = self.lstm(x) 
+        conv1_out = self.conv_1(x).transpose(1, 2).contiguous().squeeze(-1)
+        conv3_out = self.conv_3(x).transpose(1, 2).contiguous().squeeze(-1)
+        conv5_out = self.conv_5(x).transpose(1, 2).contiguous().squeeze(-1)
+        x = self.pooler(x)
+
+        return x

--- a/reader/custom_head.py
+++ b/reader/custom_head.py
@@ -25,12 +25,13 @@ class CnnQAHead(nn.Module):
         self.conv_1 = nn.Conv1d(in_channels=input_size, out_channels=2, kernel_size=1, padding=0)
         self.conv_3 = nn.Conv1d(in_channels=input_size, out_channels=2, kernel_size=3, padding=1)
         self.conv_5 = nn.Conv1d(in_channels=input_size, out_channels=2, kernel_size=5, padding=2)
+        self.relu = nn.ReLU()
 
     def forward(self, x):
         x = x.transpose(1, 2).contiguous()
-        conv1_out = self.conv_1(x).transpose(1, 2).contiguous().squeeze(-1)
-        conv3_out = self.conv_3(x).transpose(1, 2).contiguous().squeeze(-1)
-        conv5_out = self.conv_5(x).transpose(1, 2).contiguous().squeeze(-1)
+        conv1_out = self.relu(self.conv_1(x).transpose(1, 2).contiguous().squeeze(-1))
+        conv3_out = self.relu(self.conv_3(x).transpose(1, 2).contiguous().squeeze(-1))
+        conv5_out = self.relu(self.conv_5(x).transpose(1, 2).contiguous().squeeze(-1))
         x = conv1_out + conv3_out + conv5_out
 
         return x
@@ -50,17 +51,20 @@ class FcQAHead(nn.Module):
 class ComplexCnnQAHead(nn.Module):
     def __init__(self, input_size):
         super().__init__()
+        self.relu = nn.ReLU()
         self.conv_1 = nn.Conv1d(in_channels=input_size, out_channels=256, kernel_size=1, padding=0)
         self.conv_3 = nn.Conv1d(in_channels=input_size, out_channels=256, kernel_size=3, padding=1)
         self.conv_5 = nn.Conv1d(in_channels=input_size, out_channels=256, kernel_size=5, padding=2)
+        self.dropout = nn.Dropout(p=0.5)
         self.fc = nn.Linear(768, 2)
 
     def forward(self, x):
         x = x.transpose(1, 2).contiguous()
-        conv1_out = self.conv_1(x).transpose(1, 2).contiguous().squeeze(-1)
-        conv3_out = self.conv_3(x).transpose(1, 2).contiguous().squeeze(-1)
-        conv5_out = self.conv_5(x).transpose(1, 2).contiguous().squeeze(-1)
-        output = self.fc(torch.cat((conv1_out, conv3_out, conv5_out), -1))
+        conv1_out = self.relu(self.conv_1(x).transpose(1, 2).contiguous().squeeze(-1))
+        conv3_out = self.relu(self.conv_3(x).transpose(1, 2).contiguous().squeeze(-1))
+        conv5_out = self.relu(self.conv_5(x).transpose(1, 2).contiguous().squeeze(-1))
+        output = self.fc(self.dropout(torch.cat((conv1_out, conv3_out, conv5_out), -1)))
+        # output = self.fc(torch.cat((conv1_out, conv3_out, conv5_out), -1))
 
         return output
 
@@ -68,29 +72,22 @@ class ComplexCnnQAHead(nn.Module):
 class CnnLstmQAHead(nn.Module):
     def __init__(self, input_size):
         super().__init__()
-        self.em_embedding = nn.Embedding(num_embeddings=384, embedding_dim=768)
-        self.lstm = nn.LSTM(input_size=input_size, hidden_size=input_size, num_layers=3, dropout=0.5, bidirectional=True, batch_first=True)
+        self.relu = nn.ReLU()
+        self.lstm = nn.LSTM(input_size=input_size, hidden_size=input_size, num_layers=3, dropout=0.3, bidirectional=True, batch_first=True)
         self.conv_1 = nn.Conv1d(in_channels=input_size * 2, out_channels=256, kernel_size=1, padding=0)
         self.conv_3 = nn.Conv1d(in_channels=input_size * 2, out_channels=256, kernel_size=3, padding=1)
         self.conv_5 = nn.Conv1d(in_channels=input_size * 2, out_channels=256, kernel_size=5, padding=2)
+        self.dropout = nn.Dropout(p=0.3)
         self.fc = nn.Linear(768, 2)
 
     def forward(self, inputs):
-        """
-            x (8, 384)
-            exact_match_pos (8, 384)
-                = [[0, 1, 0, 0, ..., 1, 0, ...], ...]
-        """
-        x, exact_match_pos = inputs
-        
-        x = x + self.em_embedding(exact_match_pos) # (8, 384(문장길이), 768(임베딩)) => x[2] + em_embedding[2] / x[8] + em_embedding[8]
-        x, (_, _) = self.lstm(x) 
-
+        x, (_, _) = self.lstm(inputs)
         x = x.transpose(1, 2).contiguous()
-        conv1_out = self.conv_1(x).transpose(1, 2).contiguous().squeeze(-1)
-        conv3_out = self.conv_3(x).transpose(1, 2).contiguous().squeeze(-1)
-        conv5_out = self.conv_5(x).transpose(1, 2).contiguous().squeeze(-1)
-        x = self.fc(torch.cat((conv1_out, conv3_out, conv5_out), -1))
+        
+        conv1_out = self.relu(self.conv_1(x).transpose(1, 2).contiguous().squeeze(-1))
+        conv3_out = self.relu(self.conv_3(x).transpose(1, 2).contiguous().squeeze(-1))
+        conv5_out = self.relu(self.conv_5(x).transpose(1, 2).contiguous().squeeze(-1))
+        x = self.fc(self.dropout(torch.cat((conv1_out, conv3_out, conv5_out), -1)))
 
         return x
 
@@ -98,43 +95,12 @@ class CnnLstmQAHead(nn.Module):
 class ComplexCnnEmQAHead(nn.Module):
     def __init__(self, input_size):
         super().__init__()
+        self.relu = nn.ReLU()
         self.em_embedding = nn.Embedding(num_embeddings=384, embedding_dim=768)
         self.conv_1 = nn.Conv1d(in_channels=input_size, out_channels=256, kernel_size=1, padding=0)
         self.conv_3 = nn.Conv1d(in_channels=input_size, out_channels=256, kernel_size=3, padding=1)
         self.conv_5 = nn.Conv1d(in_channels=input_size, out_channels=256, kernel_size=5, padding=2)
-        self.fc = nn.Linear(768, 2)
-
-    def forward(self, inputs):
-        x, exact_match_pos = inputs
-        x = x + self.em_embedding(exact_match_pos) # (8, 384(문장길이), 768(임베딩)) => x[2] + em_embedding[2] / x[8] + em_embedding[8]
-
-        x = x.transpose(1, 2).contiguous()
-        conv1_out = self.conv_1(x).transpose(1, 2).contiguous().squeeze(-1)
-        conv3_out = self.conv_3(x).transpose(1, 2).contiguous().squeeze(-1)
-        conv5_out = self.conv_5(x).transpose(1, 2).contiguous().squeeze(-1)
-        output = self.fc(torch.cat((conv1_out, conv3_out, conv5_out), -1))
-
-        return output
-
-
-class ComplexCnnLstmQAHead(nn.Module):
-    def __init__(self, input_size):
-        super().__init__()
-        self.em_embedding = nn.Embedding(num_embeddings=384, embedding_dim=768)
-        
-        self.lstm_front = nn.LSTM(input_size=input_size, hidden_size=input_size, num_layers=3, dropout=0.5, bidirectional=True, batch_first=True)
-        
-        self.conv_1 = nn.Conv1d(in_channels=input_size * 2, out_channels=input_size, kernel_size=1, padding=0)
-        self.conv_3 = nn.Conv1d(in_channels=input_size * 2, out_channels=input_size, kernel_size=3, padding=1)
-        self.conv_5 = nn.Conv1d(in_channels=input_size * 2, out_channels=input_size, kernel_size=5, padding=2)
-        
-        self.lstm_back = nn.LSTM(input_size=input_size, hidden_size=input_size, num_layers=3, dropout=0.5, bidirectional=True, batch_first=True)
-
-        self.conv_1 = nn.Conv1d(in_channels=input_size * 2, out_channels=input_size, kernel_size=1, padding=0)
-        self.conv_3 = nn.Conv1d(in_channels=input_size * 2, out_channels=input_size, kernel_size=3, padding=1)
-        self.conv_5 = nn.Conv1d(in_channels=input_size * 2, out_channels=input_size, kernel_size=5, padding=2)
-        
-        self.dropout = nn.Dropout(p=0.5)
+        self.dropout = nn.Dropout(p=0.3)
         self.fc = nn.Linear(768, 2)
 
     def forward(self, inputs):
@@ -144,14 +110,73 @@ class ComplexCnnLstmQAHead(nn.Module):
                 = [[0, 1, 0, 0, ..., 1, 0, ...], ...]
         """
         x, exact_match_pos = inputs
-        
         x = x + self.em_embedding(exact_match_pos) # (8, 384(문장길이), 768(임베딩)) => x[2] + em_embedding[2] / x[8] + em_embedding[8]
-        x, (_, _) = self.lstm(x) 
 
         x = x.transpose(1, 2).contiguous()
-        conv1_out = self.conv_1(x).transpose(1, 2).contiguous().squeeze(-1)
-        conv3_out = self.conv_3(x).transpose(1, 2).contiguous().squeeze(-1)
-        conv5_out = self.conv_5(x).transpose(1, 2).contiguous().squeeze(-1)
-        x = self.fc(torch.cat((conv1_out, conv3_out, conv5_out), -1))
+        conv1_out = self.relu(self.conv_1(x).transpose(1, 2).contiguous().squeeze(-1))
+        conv3_out = self.relu(self.conv_3(x).transpose(1, 2).contiguous().squeeze(-1))
+        conv5_out = self.relu(self.conv_5(x).transpose(1, 2).contiguous().squeeze(-1))
+        output = self.fc(self.dropout(torch.cat((conv1_out, conv3_out, conv5_out), -1)))
 
-        return x
+        return output
+
+
+class ComplexCnnLstmEmQAHead(nn.Module):
+    def __init__(self, input_size):
+        super().__init__()
+        self.relu = nn.ReLU()
+        self.em_embedding = nn.Embedding(num_embeddings=384, embedding_dim=768)
+        self.lstm = nn.LSTM(input_size=input_size, hidden_size=input_size, num_layers=3, dropout=0.3, bidirectional=True, batch_first=True)
+        self.conv_1 = nn.Conv1d(in_channels=input_size * 2, out_channels=256, kernel_size=1, padding=0)
+        self.conv_3 = nn.Conv1d(in_channels=input_size * 2, out_channels=256, kernel_size=3, padding=1)
+        self.conv_5 = nn.Conv1d(in_channels=input_size * 2, out_channels=256, kernel_size=5, padding=2)
+        self.dropout = nn.Dropout(p=0.3)
+        self.fc = nn.Linear(768, 2)
+
+    def forward(self, inputs):
+        """
+            x (8, 384)
+            exact_match_pos (8, 384)
+                = [[0, 1, 0, 0, ..., 1, 0, ...], ...]
+        """
+        x, exact_match_pos = inputs
+        x = x + self.em_embedding(exact_match_pos) # (8, 384(문장길이), 768(임베딩)) => x[2] + em_embedding[2] / x[8] + em_embedding[8]
+
+        x, (_, _) = self.lstm(x)
+        x = x.transpose(1, 2).contiguous()
+
+        conv1_out = self.relu(self.conv_1(x).transpose(1, 2).contiguous().squeeze(-1))
+        conv3_out = self.relu(self.conv_3(x).transpose(1, 2).contiguous().squeeze(-1))
+        conv5_out = self.relu(self.conv_5(x).transpose(1, 2).contiguous().squeeze(-1))
+        output = self.fc(self.dropout(torch.cat((conv1_out, conv3_out, conv5_out), -1)))
+
+        return output
+
+
+class NewCnnQAHead(nn.Module):
+    def __init__(self, input_size):
+        super().__init__()
+        self.relu = nn.GELU()
+        self.dropout = nn.Dropout(p=0.5)
+
+        self.conv_1 = nn.Conv1d(in_channels=input_size, out_channels=256, kernel_size=1, padding=0)
+        self.conv_3 = nn.Conv1d(in_channels=input_size, out_channels=256, kernel_size=3, padding=1)
+        self.conv_5 = nn.Conv1d(in_channels=input_size, out_channels=256, kernel_size=5, padding=2)
+
+        self.fc_13 = nn.Linear(512, 128)
+        self.fc_35 = nn.Linear(512, 128)
+        self.fc_final = nn.Linear(256, 2)
+
+    def forward(self, x):
+        x = x.transpose(1, 2).contiguous()
+        conv1_out = self.relu(self.conv_1(x).transpose(1, 2).contiguous().squeeze(-1))
+        conv3_out = self.relu(self.conv_3(x).transpose(1, 2).contiguous().squeeze(-1))
+        conv5_out = self.relu(self.conv_5(x).transpose(1, 2).contiguous().squeeze(-1))
+
+        fc_13_out = self.relu(self.fc_13(self.dropout(torch.cat((conv1_out, conv3_out), -1))))
+        fc_35_out = self.relu(self.fc_35(self.dropout(torch.cat((conv3_out, conv5_out), -1))))
+
+        output = self.fc_final(self.dropout(torch.cat((fc_13_out, fc_35_out), -1)))
+        # output = self.fc(torch.cat((conv1_out, conv3_out, conv5_out), -1))
+
+        return output

--- a/reader/custom_head.py
+++ b/reader/custom_head.py
@@ -55,6 +55,25 @@ class ComplexCnnQAHead(nn.Module):
         self.conv_1 = nn.Conv1d(in_channels=input_size, out_channels=256, kernel_size=1, padding=0)
         self.conv_3 = nn.Conv1d(in_channels=input_size, out_channels=256, kernel_size=3, padding=1)
         self.conv_5 = nn.Conv1d(in_channels=input_size, out_channels=256, kernel_size=5, padding=2)
+        self.fc = nn.Linear(768, 2)
+
+    def forward(self, x):
+        x = x.transpose(1, 2).contiguous()
+        conv1_out = self.relu(self.conv_1(x).transpose(1, 2).contiguous().squeeze(-1))
+        conv3_out = self.relu(self.conv_3(x).transpose(1, 2).contiguous().squeeze(-1))
+        conv5_out = self.relu(self.conv_5(x).transpose(1, 2).contiguous().squeeze(-1))
+        output = self.fc(torch.cat((conv1_out, conv3_out, conv5_out), -1))
+
+        return output
+
+
+class ComplexCnnQAHead_v2(nn.Module):
+    def __init__(self, input_size):
+        super().__init__()
+        self.relu = nn.ReLU()
+        self.conv_1 = nn.Conv1d(in_channels=input_size, out_channels=256, kernel_size=1, padding=0)
+        self.conv_3 = nn.Conv1d(in_channels=input_size, out_channels=256, kernel_size=3, padding=1)
+        self.conv_5 = nn.Conv1d(in_channels=input_size, out_channels=256, kernel_size=5, padding=2)
         self.dropout = nn.Dropout(p=0.5)
         self.fc = nn.Linear(768, 2)
 
@@ -64,7 +83,6 @@ class ComplexCnnQAHead(nn.Module):
         conv3_out = self.relu(self.conv_3(x).transpose(1, 2).contiguous().squeeze(-1))
         conv5_out = self.relu(self.conv_5(x).transpose(1, 2).contiguous().squeeze(-1))
         output = self.fc(self.dropout(torch.cat((conv1_out, conv3_out, conv5_out), -1)))
-        # output = self.fc(torch.cat((conv1_out, conv3_out, conv5_out), -1))
 
         return output
 

--- a/reader/custom_reader.py
+++ b/reader/custom_reader.py
@@ -7,12 +7,13 @@ from trainer_qa import QuestionAnsweringTrainer
 
 from transformers.modeling_outputs import QuestionAnsweringModelOutput
 from reader.base_reader import BaseReader, EvalCallback
-from reader.custom_head import LstmQAHead, CnnQAHead, FcQAHead, ComplexCnnQAHead, CnnLstmQAHead, ComplexCnnEmQAHead, ComplexCnnLstmEmQAHead, NewCnnQAHead
+from reader.custom_head import LstmQAHead, CnnQAHead, FcQAHead, ComplexCnnQAHead, ComplexCnnQAHead_v2, CnnLstmQAHead, ComplexCnnEmQAHead, ComplexCnnLstmEmQAHead, NewCnnQAHead
 
 READER_HEAD = {"LSTM": LstmQAHead, 
                "CNN": CnnQAHead, 
                "FC": FcQAHead, 
-               "CCNN": ComplexCnnQAHead, 
+               "CCNN": ComplexCnnQAHead,
+               "CCNN_v2": ComplexCnnQAHead_v2, 
                "CNN_LSTM": CnnLstmQAHead, 
                "CCNN_EM": ComplexCnnEmQAHead, 
                "CCNN_LSTM_EM": ComplexCnnLstmEmQAHead,
@@ -23,7 +24,7 @@ class CustomModel(nn.Module):
         super().__init__()
         self.backbone = backbone
 
-        head_input_size = 1024 # 현재 embedding 768 기준, xlm-roberta-large의 경우 1024
+        head_input_size = 768 # 현재 embedding 768 기준, xlm-roberta-large의 경우 1024
         self.qa_outputs = READER_HEAD[head](input_size=head_input_size)
         self.qa_outputs.apply(self._init_weight)
 

--- a/reader/custom_reader.py
+++ b/reader/custom_reader.py
@@ -7,16 +7,23 @@ from trainer_qa import QuestionAnsweringTrainer
 
 from transformers.modeling_outputs import QuestionAnsweringModelOutput
 from reader.base_reader import BaseReader, EvalCallback
-from reader.custom_head import LstmQAHead, CnnQAHead, FcQAHead, ComplexCnnQAHead, CnnLstmQAHead, ComplexCnnEmQAHead
+from reader.custom_head import LstmQAHead, CnnQAHead, FcQAHead, ComplexCnnQAHead, CnnLstmQAHead, ComplexCnnEmQAHead, ComplexCnnLstmEmQAHead, NewCnnQAHead
 
-READER_HEAD = {"LSTM": LstmQAHead, "CNN": CnnQAHead, "FC": FcQAHead, "CCNN": ComplexCnnQAHead, "CNN_LSTM": CnnLstmQAHead, "CCNN_EM": ComplexCnnEmQAHead}
+READER_HEAD = {"LSTM": LstmQAHead, 
+               "CNN": CnnQAHead, 
+               "FC": FcQAHead, 
+               "CCNN": ComplexCnnQAHead, 
+               "CNN_LSTM": CnnLstmQAHead, 
+               "CCNN_EM": ComplexCnnEmQAHead, 
+               "CCNN_LSTM_EM": ComplexCnnLstmEmQAHead,
+               "NEW_CNN": NewCnnQAHead}
 
 class CustomModel(nn.Module):
     def __init__(self, backbone, head, pooling_pos, masking_ratio, freeze_backbone):
         super().__init__()
         self.backbone = backbone
 
-        head_input_size = 768 # 현재 embedding 768 기준, xlm-roberta-large의 경우 1024
+        head_input_size = 1024 # 현재 embedding 768 기준, xlm-roberta-large의 경우 1024
         self.qa_outputs = READER_HEAD[head](input_size=head_input_size)
         self.qa_outputs.apply(self._init_weight)
 
@@ -121,7 +128,7 @@ class CustomModel(nn.Module):
         sequence_output = outputs[0]
 
         logits = None
-        if self.head == 'CNN_LSTM' or self.head == 'CCNN_EM':
+        if self.head == 'CCNN_LSTM_EM' or self.head == 'CCNN_EM':
             exact_match_token = self.get_exact_match_token(input_ids)
             logits = self.qa_outputs((sequence_output, exact_match_token))
         else: 

--- a/run.py
+++ b/run.py
@@ -21,7 +21,7 @@ def train_reader(args):
         args.info = Namespace()
         set_seed(seed)
 
-        args.model.model_name_or_path = args.model_path
+        # args.model.model_name_or_path = args.model_path
 
         # below codes must run before 'reader.get_trainer()'
         # run_name: strategy + alias + seed


### PR DESCRIPTION
- argument에 freeze_backbone이 추가되었습니다. custom reader 학습시 해당 argument true 주면 backbone은 학습하지 않습니다. 이것도 DPR 모델은 해당 없습니다!
    ```
          },
      "train": {
          "masking_ratio": 0.0,
          "do_train": true,
          "do_eval": true,
          "do_eval_during_training": true,
          "eval_step": 200,
          "pororo_prediction": true,
          "save_total_limit": 1,
          "save_steps": 100,
          "logging_steps": 100,
          "num_train_epochs": 10.0,
          "overwrite_output_dir": true,
          "freeze_backbone": true,
          "report_to": ["wandb"]
    },
    ```
- 새로운 head 몇 개 추가 .. 유의미한 head인지는 모르겠으나 그냥 실험한 것들 중에 그나마 괜찮았던거 다 넣어놨습니다.
- exact match 위치 찾는 코드가 추가되었습니다.

**건모님 이따 모델 돌리실 때 reader_tmp 브랜치에서 prepare.py, custom_head.py, custom_reader.py만 가져가시거나 이거 PR 받아서 해주시면 됩니다!**

그리고 전에 말씀드렸다시피, 얘네들은 checkpoint 가져다 쓰려면 strategy를 다음과 같이 수정해야합니다.
경로에 **pytorch_embedding.bin**을 넣어줘야 합니다!
```
   ...
    "model": {
        "model_name_or_path": "monologg/koelectra-base-v3-finetuned-korquad",
        "model_path": "/opt/ml/input/checkpoint/..../pytorch_embedding.bin",
        "retriever_name": "ATIREBM25",
        "reader_name": "CCNN_v2",
        "config_name": "monologg/koelectra-base-v3-finetuned-korquad",
        "tokenizer_name": "xlm-roberta-large"
    },
   ...
```

그래서 run.py, predict.py에서 model_path 가져오는 부분은 주석처리 필요합니다.


따로 말 없으면 아마 아래 모델 써야할 것 같습니다. 필요한거 가져다 쓰시면 될 것 같아요
ST101_CNN_95/checkpoint-15100 => valid 63.33/78.52
ST103_CNN_LSTM_95/checkpoint-5500 => valid 60.00/67.863
ST104_CCNN_v2_95/checkpoint-15100 => valid 61.67/77.25
ST106_LSTM_95/checkpoint-1500 => valid 60/68.2